### PR TITLE
Run ocp-indent, delete trailing whitespace

### DIFF
--- a/lib/src/arm_gen.ml
+++ b/lib/src/arm_gen.ml
@@ -393,13 +393,13 @@ let insn_pretty i : (string, Errors.t) result =
 let arm_operand_pretty (o : IR.operand) : (string, Errors.t) result =
   match o with
   | Var v ->
-     let error =
-       Errors.Missing_semantics
-         "operand.pre_assign field is empty in pretty printer" in
-     Result.bind
-       (Result.of_option v.pre_assign ~error:error)
-       ~f:(fun reg ->
-         Result.return (Sexp.to_string (ARM.sexp_of_gpr_reg reg)))
+    let error =
+      Errors.Missing_semantics
+        "operand.pre_assign field is empty in pretty printer" in
+    Result.bind
+      (Result.of_option v.pre_assign ~error:error)
+      ~f:(fun reg ->
+          Result.return (Sexp.to_string (ARM.sexp_of_gpr_reg reg)))
   | Const w ->
     (* A little calisthenics to get this to look nice *)
     Result.return (Format.asprintf "#%a" Word.pp_dec w)

--- a/lib/src/arm_gen.mli
+++ b/lib/src/arm_gen.mli
@@ -20,8 +20,8 @@ open Bap_core_theory
 
 (** The ARM implementation of Theory.Core.
 
-   It can be included to write Core terms and directly obtain a
-   [Vibes_ir] from it.  *)
+    It can be included to write Core terms and directly obtain a
+    [Vibes_ir] from it.  *)
 module ARM_Core : Theory.Core
 
 (** The abstract representation of [Theory.eff] terms. *)
@@ -29,9 +29,9 @@ type arm_eff
 
 (** Deprecated: Work directly with terms parametrized over S : Core *)
 module BilARM :
-  sig
-    val run : ('e, 'r, 's) Theory.Parser.t -> 's list -> unit Theory.eff
-  end
+sig
+  val run : ('e, 'r, 's) Theory.Parser.t -> 's list -> unit Theory.eff
+end
 
 (** Deprecated: Work directly with terms parametrized over S : Core *)
 val bil_to_arm : (Bil.exp, unit, Bil.stmt) Theory.Parser.t
@@ -40,7 +40,7 @@ val bil_to_arm : (Bil.exp, unit, Bil.stmt) Theory.Parser.t
 val effect : 'a Theory.effect -> arm_eff option
 
 (** Extracts the concrete [Vibes_ir] from the abstract [arm_eff]
-   representation. *)
+    representation. *)
 val ir : arm_eff -> Vibes_ir.t
 
 (** Pretty prints [ir] terms in a form suitable for assembly *)

--- a/lib/src/compiler.ml
+++ b/lib/src/compiler.ml
@@ -14,15 +14,15 @@ module KB = Knowledge
 let create_assembly ?solver:(solver = Minizinc.run_minizinc) (bil : Bil.t) : string list KB.t =
   let value_exn x = Option.value_exn x in
   Arm_gen.BilARM.run Arm_gen.bil_to_arm bil >>|
-    (fun v -> v
-    |> Arm_gen.effect
-    |> value_exn
-    |> Arm_gen.ir) 
-    >>= solver 
-    >>| Arm_gen.arm_ir_pretty 
-    >>= (function
-        | Ok assembly -> KB.return assembly
-        | Error e -> Errors.fail e)
+  (fun v -> v |>
+            Arm_gen.effect |>
+            value_exn |>
+            Arm_gen.ir) >>=
+  solver  >>|
+  Arm_gen.arm_ir_pretty >>=
+  (function
+    | Ok assembly -> KB.return assembly
+    | Error e -> Errors.fail e)
 
 (* Converts the patch (as BIL) to assembly instructions. *)
 let compile ?solver:(solver = Minizinc.run_minizinc)(obj : Data.t) : unit KB.t =

--- a/lib/src/compiler.mli
+++ b/lib/src/compiler.mli
@@ -1,5 +1,5 @@
 (* Compiles the patch.
- 
+
    This module is responsible for taking the patch code (BIL statements)
    that was ingested by the {!Patch_ingester}, and "compiling" it to
    assembly (or something like it) for the target architecture. *)
@@ -7,6 +7,6 @@
 open Bap_knowledge
 module KB = Knowledge
 
-(* [compile obj] converts the patch (which is BIL) associated with 
-   the provided [obj] into assembly. *)
+(* [compile obj] converts the patch (which is BIL) associated with the
+   provided [obj] into assembly. *)
 val compile : ?solver:(Vibes_ir.t -> Vibes_ir.t KB.t) -> Data.t -> unit KB.t

--- a/lib/src/config.ml
+++ b/lib/src/config.ml
@@ -25,7 +25,7 @@ module Errors = struct
       | Invalid_hex desc -> desc
       | Invalid_property desc -> desc
     in
-  Format.fprintf ppf "@[%s@]" msg
+    Format.fprintf ppf "@[%s@]" msg
 
 end
 
@@ -57,27 +57,27 @@ let max_tries t : int option = t.max_tries
 (* For printing configuration. *)
 let pp (ppf : Format.formatter) t : unit =
   let info = String.concat ~sep:"\n" [
-    Printf.sprintf "Exe: %s" t.exe;
-    Printf.sprintf "Patch: %s" t.patch;
-    Printf.sprintf "Patch_point: %s" (Bitvec.to_string t.patch_point);
-    Printf.sprintf "Patch_size: %d" t.patch_size;
-    Printf.sprintf "Property: %s" (Sexp.to_string t.property);
-    Printf.sprintf "Output filepath: %s"
-      (Option.value t.patched_exe_filepath ~default:"none provided");
-    Printf.sprintf "Max tries: %d" (Option.value t.max_tries ~default:0);
-  ] in
+      Printf.sprintf "Exe: %s" t.exe;
+      Printf.sprintf "Patch: %s" t.patch;
+      Printf.sprintf "Patch_point: %s" (Bitvec.to_string t.patch_point);
+      Printf.sprintf "Patch_size: %d" t.patch_size;
+      Printf.sprintf "Property: %s" (Sexp.to_string t.property);
+      Printf.sprintf "Output filepath: %s"
+        (Option.value t.patched_exe_filepath ~default:"none provided");
+      Printf.sprintf "Max tries: %d" (Option.value t.max_tries ~default:0);
+    ] in
   Format.fprintf ppf "@[%s@]@." info
 
 (* Error if a string is empty. *)
-let is_not_empty (value : string) (e : Errors.t) 
-    : (string, error) Stdlib.result =
+let is_not_empty (value : string) (e : Errors.t)
+  : (string, error) Stdlib.result =
   match String.length value with
   | 0 -> Err.fail e
   | _ -> Err.return value
 
 (* Parse a hex string into a bitvector, or error. *)
 let validate_patch_point (value : string) : (Bitvec.t, error) Stdlib.result =
-  try 
+  try
     Err.return (Bitvec.of_string value)
   with Invalid_argument _ ->
     let msg = Format.sprintf "Invalid hex string: %s" value in
@@ -97,13 +97,13 @@ let create ~exe:(exe : string) ~patch:(patch : string)
     ~property:(property : string)
     ~patched_exe_filepath:(patched_exe_filepath : string option)
     ~max_tries:(max_tries : int option)
-    : (t, error) result =
+  : (t, error) result =
   is_not_empty exe Errors.Missing_exe >>= fun exe ->
   is_not_empty patch Errors.Missing_patch >>= fun patch ->
   is_not_empty patch_point Errors.Missing_patch_point >>= fun patch_point ->
   is_not_empty property Errors.Missing_property >>= fun property ->
   validate_patch_point patch_point >>= fun patch_point ->
   validate_property property >>= fun property ->
-  let record = { exe; patch; patch_point; patch_size; property; 
-    patched_exe_filepath; max_tries } in
+  let record = { exe; patch; patch_point; patch_size; property;
+                 patched_exe_filepath; max_tries } in
   Ok record

--- a/lib/src/core_notations.ml
+++ b/lib/src/core_notations.ml
@@ -46,7 +46,7 @@ module Make (C : Core) = struct
     List.fold ~init:empty ~f:seq l
 
   (** Sequences a list of control effects, ending them with a
-     fall-through *)
+      fall-through *)
   let ctrl_body (l : ctrl eff list) : ctrl eff =
     let empty = perform Effect.Sort.fall in
     List.fold ~init:empty ~f:seq l

--- a/lib/src/data.ml
+++ b/lib/src/data.ml
@@ -10,34 +10,34 @@ module KB = Knowledge
 
 (* Optional string domain *)
 let string_domain : String.t option KB.Domain.t = KB.Domain.optional
-  ~equal:String.(=)
-  "string-domain"
+    ~equal:String.(=)
+    "string-domain"
 
 (* Optional int domain *)
 let int_domain : int option KB.Domain.t = KB.Domain.optional
-  ~equal:Int.(=)
-  "int-domain"
+    ~equal:Int.(=)
+    "int-domain"
 
 (* Optional bitvector domain *)
 let bitvec_domain : Bitvec.t option KB.Domain.t = KB.Domain.optional
-  ~equal:Bitvec.equal
-  "bitvec-domain"
+    ~equal:Bitvec.equal
+    "bitvec-domain"
 
 (* Optional program domain *)
 let prog_domain : Program.t option KB.Domain.t = KB.Domain.optional
-  ~equal:Program.equal
-  "prog-domain"
+    ~equal:Program.equal
+    "prog-domain"
 
 (* Optional s-expression domain (for correctness properties) *)
 let property_domain : Sexp.t option KB.Domain.t = KB.Domain.optional
-  ~equal:Sexp.equal
-  "property-domain"
+    ~equal:Sexp.equal
+    "property-domain"
 
 (* Optional string list domain (for assembly). But as per
    Ivan's suggestion, we'll probably make this a powerset domain. *)
-let assembly_domain : string list option KB.Domain.t = KB.Domain.optional 
-  ~equal:(fun x y -> List.equal String.equal x y) 
-  "assembly-domain"
+let assembly_domain : string list option KB.Domain.t = KB.Domain.optional
+    ~equal:(fun x y -> List.equal String.equal x y)
+    "assembly-domain"
 
 (* General knowledge info for the package *)
 type cls = Data
@@ -55,7 +55,7 @@ module Patch = struct
   let bil : (cls, Bil.t) KB.slot =
     KB.Class.property ~package cls "patch-bil" Bil.domain
 
-  let assembly : (cls, string list option) KB.slot = 
+  let assembly : (cls, string list option) KB.slot =
     KB.Class.property ~package cls "patch-assembly" assembly_domain
 
   let set_patch_name (obj : t) (data : string option) : unit KB.t =
@@ -93,17 +93,17 @@ end
 (* Properties pertaining to the original executable *)
 module Original_exe = struct
 
-  let filepath : (cls, string option) KB.slot = 
-    KB.Class.property ~package cls "original-exe-filepath" 
-    string_domain
+  let filepath : (cls, string option) KB.slot =
+    KB.Class.property ~package cls "original-exe-filepath"
+      string_domain
 
   let prog : (cls, Program.t option) KB.slot =
     KB.Class.property ~package cls "original-exe-prog"
-    prog_domain
+      prog_domain
 
   let addr_size : (cls, int option) KB.slot =
     KB.Class.property ~package cls "original-exe-address-size"
-    int_domain
+      int_domain
 
   let set_filepath (obj : t) (data : string option) : unit KB.t =
     KB.provide filepath obj data
@@ -148,11 +148,11 @@ module Patched_exe = struct
 
   let filepath : (cls, string option) KB.slot =
     KB.Class.property ~package cls "patched-exe-filepath"
-    string_domain
+      string_domain
 
   let tmp_filepath : (cls, string option) KB.slot =
     KB.Class.property ~package cls "tmp-patched-exe-filepath"
-    string_domain
+      string_domain
 
   let patch_point : (cls, Bitvec.t option) KB.slot =
     KB.Class.property ~package cls "patch-point" bitvec_domain
@@ -231,7 +231,7 @@ module Verifier = struct
 end
 
 (* Create an object of this class. *)
-let create (config : Config.t) : t KB.t = 
+let create (config : Config.t) : t KB.t =
   let exe = Config.exe config in
   let patch = Config.patch config in
   let patch_point = Config.patch_point config in
@@ -266,5 +266,5 @@ let fresh ~property:(property : Sexp.t) (obj : t) : t KB.t =
   Patched_exe.set_patch_point obj' patch_point >>= fun _ ->
   Patched_exe.get_patch_size obj >>= fun patch_size ->
   Patched_exe.set_patch_size obj' patch_size >>= fun _ ->
-  Verifier.set_property obj' (Some property) >>= fun _ -> 
+  Verifier.set_property obj' (Some property) >>= fun _ ->
   KB.return obj'

--- a/lib/src/errors.ml
+++ b/lib/src/errors.ml
@@ -51,7 +51,7 @@ let pp ppf (e : t) =
     | Exit_code s -> s
     | Unexpected_exit s -> s
     | WP_result_unknown s -> s
-    | Max_tries n -> Format.sprintf "Tried %d times. Giving up" n 
+    | Max_tries n -> Format.sprintf "Tried %d times. Giving up" n
     | Minizinc_deserialization s -> s
     | Other s -> s
   in

--- a/lib/src/events.mli
+++ b/lib/src/events.mli
@@ -1,7 +1,7 @@
 (* An event stream for the VIBES pipeline.
 
    This module provides an event stream that modules in the VIBES pipeline
-   can send messages to, for logging/communication. 
+   can send messages to, for logging/communication.
 
    If the user has enabled verbose logging, the {!Verbose} module will
    subscribe to this stream, and report all events. *)

--- a/lib/src/exe_ingester.ml
+++ b/lib/src/exe_ingester.ml
@@ -26,7 +26,7 @@ let ingest ?loader:(loader=Exe_loader.load) (obj : Data.t) : unit KB.t =
   Events.(send @@ Info "Retreiving data from KB...");
   Data.Original_exe.get_filepath_exn obj >>= fun filepath ->
 
-  Events.(send @@ Info (Format.sprintf "Loading into BAP: %s..." filepath)); 
+  Events.(send @@ Info (Format.sprintf "Loading into BAP: %s..." filepath));
 
   (* Load the project and stash the program in the KB. *)
   loader filepath >>= fun project ->

--- a/lib/src/minizinc.ml
+++ b/lib/src/minizinc.ml
@@ -8,8 +8,8 @@ module KB = Knowledge
 open Knowledge.Syntax
 
 
-(** 
-   [mzn_params] Type for interfacing with ocaml code 
+(**
+   [mzn_params] Type for interfacing with ocaml code
 
    [copy] a set of operations that are copy operations. Just give an empty set for now.
    [definer] map from temporary to operation that defines it
@@ -29,10 +29,10 @@ type mzn_params = {
   definer : VIR.op_var Var.Map.t;
   users : (VIR.op_var list) Var.Map.t;
   temp_block : tid Var.Map.t;
-  latency : unit; 
+  latency : unit;
   (* width : int Var.Map.t; Vars in Bap have width. Unnecessary? *)
   preassign : string Var.Map.t;
-  operation_insns : (Vibes_ir.insn list) Tid.Map.t; 
+  operation_insns : (Vibes_ir.insn list) Tid.Map.t;
   operand_operation : VIR.operation Var.Map.t;
   congruent : (VIR.op_var * VIR.op_var) list ;
   operands : Var.Set.t;
@@ -40,7 +40,7 @@ type mzn_params = {
 }
 
 (** [mzn_params_of_vibes_ir] converts a VIR.t subroutine into the intermediate data
-    structure mzn_params 
+    structure mzn_params
     TODO Unimplemented:
        * No copy instructions
        * Latency
@@ -49,7 +49,7 @@ type mzn_params = {
 let mzn_params_of_vibes_ir (sub : VIR.t) : mzn_params =
   {
     copy = Tid.Set.empty;
-    definer = VIR.definer_map sub; 
+    definer = VIR.definer_map sub;
     users = VIR.users_map sub;
     temp_block = VIR.temp_blk sub;
     latency = ();
@@ -62,23 +62,23 @@ let mzn_params_of_vibes_ir (sub : VIR.t) : mzn_params =
   }
 
 
-(* Convenience types for minizinc serialization. At this point nearly everything 
+(* Convenience types for minizinc serialization. At this point nearly everything
    becomes stringly typed. The {set :} and {e : } wrappers produce the correct json
    for serialization to minzinc *)
-type 'a mznset = {set : 'a list}  [@@deriving yojson] 
-type ('a ,'b) mznmap = 'b list 
+type 'a mznset = {set : 'a list}  [@@deriving yojson]
+type ('a ,'b) mznmap = 'b list
 
-(* Phantom types make yojson_deriving produce function with unused variables. 
+(* Phantom types make yojson_deriving produce function with unused variables.
    This sets off a warning *)
 let mznmap_of_yojson = fun _ -> [%of_yojson: 'b list]
 let mznmap_to_yojson = fun _ -> [%to_yojson: 'b list]
 
-type mzn_enum = {e : string} [@@deriving yojson] 
+type mzn_enum = {e : string} [@@deriving yojson]
 type mzn_enum_def = mzn_enum mznset [@@deriving yojson] (* https://github.com/MiniZinc/libminizinc/issues/441 *)
-type operand = mzn_enum [@@deriving yojson] 
-type operation = mzn_enum [@@deriving yojson] 
-type block = mzn_enum [@@deriving yojson] 
-type temp = mzn_enum [@@deriving yojson] 
+type operand = mzn_enum [@@deriving yojson]
+type operation = mzn_enum [@@deriving yojson]
+type block = mzn_enum [@@deriving yojson]
+type temp = mzn_enum [@@deriving yojson]
 type insn = mzn_enum [@@deriving yojson]
 type reg = mzn_enum [@@deriving yojson]
 
@@ -119,7 +119,7 @@ type serialization_info = {
 }
 
 (** [serialize_man_params] converts the intermediate structure into the serializable structure
-    [mzn_params_serial] and retains [serialization_info]. These two structures are produced at 
+    [mzn_params_serial] and retains [serialization_info]. These two structures are produced at
     the same time to hopefully keep close linkage between them.
 
     TODO:
@@ -128,23 +128,23 @@ type serialization_info = {
        Implement latency
 
 *)
-let serialize_mzn_params (vir : Vibes_ir.t) : mzn_params_serial * serialization_info = 
+let serialize_mzn_params (vir : Vibes_ir.t) : mzn_params_serial * serialization_info =
   let params = mzn_params_of_vibes_ir vir in
   let temps = Var.Set.to_list params.temps in
-  let temp_names = List.map ~f:(fun t -> Var.sexp_of_t t |> Sexp.to_string) temps in 
-  let insns = Tid.Map.data params.operation_insns |> List.concat_map 
-                ~f:(fun is -> List.map is ~f:(fun i -> Vibes_ir.sexp_of_insn i 
+  let temp_names = List.map ~f:(fun t -> Var.sexp_of_t t |> Sexp.to_string) temps in
+  let insns = Tid.Map.data params.operation_insns |> List.concat_map
+                ~f:(fun is -> List.map is ~f:(fun i -> Vibes_ir.sexp_of_insn i
                                                        |>  Ppx_sexp_conv_lib.Sexp.to_string))
               |> String.Set.of_list |> String.Set.to_list in
   let blocks = Var.Map.data params.temp_block |> Tid.Set.of_list |> Tid.Set.to_list in
   let operations = Tid.Map.keys params.operation_insns in
-  let operands = Var.Set.to_list params.operands(* Var.Map.keys params.operand_operation *) in  
+  let operands = Var.Set.to_list params.operands(* Var.Map.keys params.operand_operation *) in
   let width t = match Var.typ t with
     | Imm n -> Float.( (of_int n) / 32.0 |> round_up |> to_int) (* fishy. Use divmod? *)
     | _ -> failwith "width unimplemented for Mem or Unk"
   in
   {
-    reg_t = mzn_enum_def_of_list (List.map 
+    reg_t = mzn_enum_def_of_list (List.map
                                     ~f:(fun r -> ARM.sexp_of_gpr_reg r |> Sexp.to_string)
                                     ARM.all_of_gpr_reg);
     insn_t = mzn_enum_def_of_list insns;
@@ -153,15 +153,15 @@ let serialize_mzn_params (vir : Vibes_ir.t) : mzn_params_serial * serialization_
     operation_t = mzn_enum_def_of_list (List.map operations ~f:Tid.to_string);
     block_t = List.map ~f:Tid.to_string blocks |>  mzn_enum_def_of_list;
     class_t = {set = [{e = "unimplemented_class"}]};
-    operand_operation = List.map ~f:(fun t -> Var.Map.find_exn params.operand_operation t 
+    operand_operation = List.map ~f:(fun t -> Var.Map.find_exn params.operand_operation t
                                               |> VIR.operation_to_string |> mzn_enum ) operands;
     definer = List.map ~f:(fun t -> Var.Map.find_exn params.definer t |> VIR.op_var_to_string
                                     |> mzn_enum) temps;
     users = List.map ~f:(fun t -> match Var.Map.find params.users t with
         | None -> {set = []}
         | Some operands -> {
-            set = List.map 
-                ~f:(fun o -> VIR.op_var_to_string o |> mzn_enum) operands} ) 
+            set = List.map
+                ~f:(fun o -> VIR.op_var_to_string o |> mzn_enum) operands} )
         temps;
     temp_block = List.map temps
         ~f:(fun t -> Var.Map.find_exn params.temp_block t |> Tid.to_string |> mzn_enum);
@@ -172,8 +172,8 @@ let serialize_mzn_params (vir : Vibes_ir.t) : mzn_params_serial * serialization_
     preassign = List.map ~f:(fun _ -> {set = []} ) operands ; (* TODO *)
     congruent = List.map ~f:(fun _ -> {set = []} ) operands ; (* TODO *)
     operation_insns = List.map ~f:(fun o ->
-        {set = Tid.Map.find_exn params.operation_insns o 
-               |> List.map ~f:(fun i -> Vibes_ir.sexp_of_insn i 
+        {set = Tid.Map.find_exn params.operation_insns o
+               |> List.map ~f:(fun i -> Vibes_ir.sexp_of_insn i
                                         |> Ppx_sexp_conv_lib.Sexp.to_string |> mzn_enum )
         }) operations;
     latency = List.map ~f:(fun _ -> 10) insns (* TODO *)
@@ -186,7 +186,7 @@ let serialize_mzn_params (vir : Vibes_ir.t) : mzn_params_serial * serialization_
   }
 
 (* [sol_serial] is a datatype for deserialization the minzinc variables via yojson *)
-type sol_serial = { 
+type sol_serial = {
   (* _objective : int ;  Optimization is currently not implemented *)
   reg : (temp ,reg) mznmap;
   insn : (operation , insn) mznmap;
@@ -198,22 +198,22 @@ type sol_serial = {
   end_cycle : int list
 } [@@deriving yojson]
 
-(** 
+(**
    [sol] is produced by processing [sol_serial]
 
    [reg] is a mapping from temporaries to registers
    [insn] is a mapping from operations to instructions
    [temp] is a mapping from operands to temps
    [active] is a mapping from operations to booleans
-   [issue] is a mapping from operations to the issue cycle on which they execute   
+   [issue] is a mapping from operations to the issue cycle on which they execute
 *)
 
 type sol = {
   reg : ARM.gpr_reg Var.Map.t;
-  insn : Vibes_ir.insn Tid.Map.t; 
-  temp : Var.t Var.Map.t; 
-  active : bool Tid.Map.t; 
-  issue : int Tid.Map.t; 
+  insn : Vibes_ir.insn Tid.Map.t;
+  temp : Var.t Var.Map.t;
+  active : bool Tid.Map.t;
+  issue : int Tid.Map.t;
 }
 
 
@@ -230,15 +230,15 @@ let deserialize_sol (s : sol_serial) (names : serialization_info) : sol =
   let reg = List.map ~f:(fun r -> Sexp.of_string r.e |> ARM.gpr_reg_of_sexp) s.reg in
   {
     reg =  List.zip_exn names.temps reg |> Var.Map.of_alist_exn;
-    insn = List.map2_exn  
-        ~f:(fun op insn -> (op ,  Sexp.of_string insn |> Vibes_ir.insn_of_sexp ))  
-        names.operations 
-        (strip_enum s.insn) 
+    insn = List.map2_exn
+        ~f:(fun op insn -> (op ,  Sexp.of_string insn |> Vibes_ir.insn_of_sexp ))
+        names.operations
+        (strip_enum s.insn)
            |> Tid.Map.of_alist_exn;
-    temp = List.map2_exn  
-        ~f:(fun op temp -> (op , String.Map.find_exn names.temp_map temp )) 
+    temp = List.map2_exn
+        ~f:(fun op temp -> (op , String.Map.find_exn names.temp_map temp ))
         names.operands
-        (strip_enum s.temp) 
+        (strip_enum s.temp)
            |> Var.Map.of_alist_exn;
     active = List.zip_exn names.operations s.active |> Tid.Map.of_alist_exn;
     issue = List.zip_exn names.operations s.issue |> Tid.Map.of_alist_exn
@@ -252,24 +252,24 @@ let apply_sol (vir : VIR.t) (sol : sol) : VIR.t =
   (* Filter inactive operations, and sort operations by issue cycle *)
   let vir = VIR.map_blks vir ~f:(fun b ->
       { id = b.id ;
-        operations = List.filter ~f:(fun o -> Tid.Map.find_exn sol.active o.id) b.operations |> 
+        operations = List.filter ~f:(fun o -> Tid.Map.find_exn sol.active o.id) b.operations |>
                      List.sort ~compare:(fun o1 o2 -> compare_int (Tid.Map.find_exn sol.issue o1.id )
                                             (Tid.Map.find_exn sol.issue o2.id ) )  ;
-        ins = b.ins ; 
-        outs = b.outs ; 
-        frequency = b.frequency } 
+        ins = b.ins ;
+        outs = b.outs ;
+        frequency = b.frequency }
     ) in
   (* Put register and temporary selection into operands *)
-  let vir = VIR.map_op_vars vir ~f:(fun o -> 
-      let temp = Var.Map.find_exn sol.temp o.id in 
+  let vir = VIR.map_op_vars vir ~f:(fun o ->
+      let temp = Var.Map.find_exn sol.temp o.id in
       let reg = Var.Map.find_exn sol.reg temp in
       { id = o.id  ; temps = [temp] ; pre_assign = Some reg  } ) in
   (*  Set instruction field of operation *)
-  let vir = VIR.map_operations vir ~f:(fun o -> 
+  let vir = VIR.map_operations vir ~f:(fun o ->
       {
         id = o.id;
-        lhs = o.lhs; 
-        insns = [ Tid.Map.find_exn sol.insn o.id ]; 
+        lhs = o.lhs;
+        insns = [ Tid.Map.find_exn sol.insn o.id ];
         optional =  not (Tid.Map.find_exn sol.active o.id);
         operands = o.operands;
       } ) in
@@ -277,33 +277,33 @@ let apply_sol (vir : VIR.t) (sol : sol) : VIR.t =
 
 let model = Model.model
 
-let run_minizinc (vir : VIR.t) : VIR.t KB.t = 
+let run_minizinc (vir : VIR.t) : VIR.t KB.t =
   let model_filename =
     Stdlib.Filename.temp_file "vibes-model" ".mzn" in
   let params_filename =
     Stdlib.Filename.temp_file "vibes-mzn-params" ".json" in
   let solution_filename =
     Stdlib.Filename.temp_file "vibes-mzn-sol" ".json" in
-  Out_channel.with_file model_filename 
+  Out_channel.with_file model_filename
     ~f:(fun out -> Out_channel.fprintf out "%s\r\n" model);
   Events.(send @@ Info (sprintf "Paramfile: %s\n" params_filename));
   Events.(send @@ Info (sprintf "Orig VIR: %s\n" (VIR.pretty_ir vir)));
   let params, name_maps = serialize_mzn_params vir in
   Yojson.Safe.to_file params_filename (mzn_params_serial_to_yojson params);
-  let minizinc_args = ["--output-mode"; "json"; 
-                       "-o"; solution_filename ; 
-                       "--output-objective" ; 
+  let minizinc_args = ["--output-mode"; "json";
+                       "-o"; solution_filename ;
+                       "--output-objective" ;
                        "-d" ; params_filename ;
                        "--soln-sep"; "\"\"";  (* Suppress some unwanted annotations *)
                        "--search-complete-msg" ;"\"\"" ;
                        model_filename ] in
-  Utils.run_process_exn "minizinc" minizinc_args >>= fun () -> 
+  Utils.run_process_exn "minizinc" minizinc_args >>= fun () ->
   let sol_serial = Yojson.Safe.from_file solution_filename |> sol_serial_of_yojson  in
   let sol = match sol_serial with
     | Ok sol_serial -> KB.return (deserialize_sol sol_serial name_maps)
     | Error msg -> Errors.fail (Errors.Minizinc_deserialization msg) in
 
-  sol >>= fun sol -> 
+  sol >>= fun sol ->
   let vir' = apply_sol vir sol in
   Events.(send @@ Info (sprintf "Solved VIR: %s\n" (VIR.pretty_ir vir)));
   KB.return vir'

--- a/lib/src/minizinc.mli
+++ b/lib/src/minizinc.mli
@@ -5,7 +5,7 @@ open Bap_knowledge
 module KB = Knowledge
 
 (**
-   [run_minzinc] encodes the VIR.t to a json file, calls minizinc, and interpets 
+   [run_minzinc] encodes the VIR.t to a json file, calls minizinc, and interpets
    the solution.
 *)
 
@@ -14,15 +14,15 @@ val run_minizinc : Vibes_ir.t -> Vibes_ir.t KB.t
 
 (* Exposed for unit testing. *)
 
-type 'a mznset = {set : 'a list}  [@@deriving yojson] 
-type ('a ,'b) mznmap = 'b list 
+type 'a mznset = {set : 'a list}  [@@deriving yojson]
+type ('a ,'b) mznmap = 'b list
 
-type mzn_enum = {e : string} [@@deriving yojson] 
+type mzn_enum = {e : string} [@@deriving yojson]
 type mzn_enum_def = mzn_enum mznset [@@deriving yojson] (* https://github.com/MiniZinc/libminizinc/issues/441 *)
-type operand = mzn_enum [@@deriving yojson] 
-type operation = mzn_enum [@@deriving yojson] 
-type block = mzn_enum [@@deriving yojson] 
-type temp = mzn_enum [@@deriving yojson] 
+type operand = mzn_enum [@@deriving yojson]
+type operation = mzn_enum [@@deriving yojson]
+type block = mzn_enum [@@deriving yojson]
+type temp = mzn_enum [@@deriving yojson]
 type insn = mzn_enum [@@deriving yojson]
 type reg = mzn_enum [@@deriving yojson]
 
@@ -57,10 +57,10 @@ val serialize_mzn_params : Vibes_ir.t -> mzn_params_serial * serialization_info
 
 type sol = {
   reg : ARM.gpr_reg Var.Map.t;
-  insn : Vibes_ir.insn Tid.Map.t; 
-  temp : Var.t Var.Map.t; 
-  active : bool Tid.Map.t; 
-  issue : int Tid.Map.t; 
+  insn : Vibes_ir.insn Tid.Map.t;
+  temp : Var.t Var.Map.t;
+  active : bool Tid.Map.t;
+  issue : int Tid.Map.t;
 }
 
 val apply_sol : Vibes_ir.t -> sol -> Vibes_ir.t

--- a/lib/src/model.ml
+++ b/lib/src/model.ml
@@ -26,7 +26,7 @@ array[temp_t] of operand_t : definer; %map from temporary to operand that define
 array[temp_t] of set of operand_t : users; %map from temporary to operands that possibly use it
 array[temp_t] of block_t : temp_block; % map from temporary to block it lives in
 
-set of operation_t : copy; % is operation a copy operation 
+set of operation_t : copy; % is operation a copy operation
 % maybe this should be a mapping from operation_t to operation_class_t
 % copy, normal (linear), in, out, jmp
 array[temp_t] of int : width; % Atom width of temporary. Atoms are subpieces of registers. Maybe 8 bit.
@@ -113,9 +113,9 @@ constraint forall(t in temp_t)(
 %C1.1
 % no overlap constraint for live register usage
 % use cumulative?
-% use minizinc built-in diffn. 
+% use minizinc built-in diffn.
 % The original unison model uses many different options
-function array[int] of var int : block_array(array[temp_t] of var int : a, block_t : b) = 
+function array[int] of var int : block_array(array[temp_t] of var int : a, block_t : b) =
     [a[t] | t in temp_t where temp_block[t] = b ];
 
 % [diffn_nonstrict]  https://www.minizinc.org/doc-latest/en/lib-globals.html#packing-constraints
@@ -123,12 +123,12 @@ function array[int] of var int : block_array(array[temp_t] of var int : a, block
 % sizes ( dx [ i ], dy [ i ]), to be non-overlapping. Zero-width rectangles can be packed anywhere.
 
 % still need to include live[t] condition
-constraint forall(b in block_t)( 
+constraint forall(b in block_t)(
         diffn(block_array(reg,b),  % built in global minizinc constraint
-              block_array(start_cycle,b), 
+              block_array(start_cycle,b),
             %  block_array([width[t] * bool2int(live[t]) | t in temp_t ], b), % no this is bad
             block_array(width, b),
-              [end_cycle[t] - start_cycle[t] | t in temp_t]) 
+              [end_cycle[t] - start_cycle[t] | t in temp_t])
 );
 
 
@@ -144,7 +144,7 @@ constraint forall(p in operand_t) (
 /*
 constraint forall(p in operand_t where active[operand_operation[p]](
     reg[temp[p]] in class[]
-    
+
 )
 */
 
@@ -210,9 +210,9 @@ constraint forall (t in temp_t)(
 %C10 Then end cycle of a temporary is the last issue cycle of operations that use it.
 constraint forall (t in temp_t where card(users[t]) > 0 /\\ live[t])(
 
-   end_cycle[t] == max( 
+   end_cycle[t] == max(
       % [ start[t] + 10 ] ++  % a kludge to make minizinc not upset when users[t] is empty.
-       [ issue[operand_operation[p]]  | p in users[t] where temp[p] == t  ]  ) 
+       [ issue[operand_operation[p]]  | p in users[t] where temp[p] == t  ]  )
        % shouldn't this also be contingent on whether the user is active?
        % I suppose the temporary won't be live then.
 );

--- a/lib/src/patch_ingester.ml
+++ b/lib/src/patch_ingester.ml
@@ -4,7 +4,7 @@ open Bap.Std
 open Bap_knowledge
 open Knowledge.Syntax
 
-module KB = Knowledge 
+module KB = Knowledge
 
 (* Loads the BIL version of a patch. For now, we select from a hand-written
    set of patches defined in the {!Patches} module. *)

--- a/lib/src/patcher.mli
+++ b/lib/src/patcher.mli
@@ -2,18 +2,18 @@
 
    This module is responsible for taking the assembly-like instructions
    produced by the {!Compiler}, converting it into binary instructions,
-   and then splicing that binary code into (a copy of) the original 
+   and then splicing that binary code into (a copy of) the original
    executable, thereby producing a new, patched executable. *)
 
 open Bap_knowledge
 module KB = Knowledge
 
-(* [patch ~patcher obj] uses the [patcher] function to patch the original 
-   executable associated with the provided [obj]. 
-   
+(* [patch ~patcher obj] uses the [patcher] function to patch the original
+   executable associated with the provided [obj].
+
    The [patcher] can be any function that takes a filepath (a [string]),
    a patch point (an address [Bitvec.t] in the original executable),
    and a list of assembly instructions (a [string list]), and returns
    a filepath (a [string]) to the patched executable. *)
 val patch : ?patcher:(string -> string list -> Bitvec.t -> string KB.t) ->
-    Data.t -> unit KB.t
+  Data.t -> unit KB.t

--- a/lib/src/patches.ml
+++ b/lib/src/patches.ml
@@ -15,8 +15,8 @@ module Ret_3 = struct
     let w = Word.of_int 3 ~width:bits in
     let three = Bil.int w in
     Bil.([
-      r0 := three;
-    ])
+        r0 := three;
+      ])
 
 end
 
@@ -29,15 +29,15 @@ module Ret_4 = struct
     let w = Word.of_int 4 ~width:bits in
     let four = Bil.int w in
     Bil.([
-      r0 := four;
-    ])
+        r0 := four;
+      ])
 
 end
 
 (* The names of the patches. *)
 let patches = Map.of_alist_exn (module String) [
-  "ret-3", Ret_3.bil;
-  "ret-4", Ret_4.bil; ]
+    "ret-3", Ret_3.bil;
+    "ret-4", Ret_4.bil; ]
 
 (* Helpers. *)
 let names = Map.keys patches

--- a/lib/src/pipeline.ml
+++ b/lib/src/pipeline.ml
@@ -7,7 +7,7 @@ open Knowledge.Syntax
 module KB = Knowledge
 
 (* Fail if the count is more than max_tries. *)
-let halt_if_too_many (count : int) (max_tries : int option) : unit KB.t = 
+let halt_if_too_many (count : int) (max_tries : int option) : unit KB.t =
   match max_tries with
   | None -> KB.return ()
   | Some 0 -> KB.return ()
@@ -17,8 +17,8 @@ let halt_if_too_many (count : int) (max_tries : int option) : unit KB.t =
 
 (* The main CEGIS loop. This compiles the patch into assembly, splices the
    new code into the original exe, and then checks if the patched exe is
-   correct. If not, it repeats the process. *) 
-let rec cegis ?count:(count=0) ?max_tries:(max_tries=None) 
+   correct. If not, it repeats the process. *)
+let rec cegis ?count:(count=0) ?max_tries:(max_tries=None)
     (obj : Data.t) : Data.t KB.t =
 
   Events.(send @@ Header "Starting CEGIS iteration");
@@ -34,7 +34,7 @@ let rec cegis ?count:(count=0) ?max_tries:(max_tries=None)
   Verifier.verify obj >>= fun next_step ->
   match next_step with
   | Verifier.Done -> KB.return obj
-  | Verifier.Again property -> 
+  | Verifier.Again property ->
     begin
       Data.fresh obj ~property >>= fun obj' ->
       cegis obj' ~count:(count + 1) ~max_tries
@@ -75,27 +75,27 @@ let run (config : Config.t) : (string, KB.Conflict.t) result =
       in
       match (original_exe_filepath, tmp_patched_exe_filepath) with
       | (Some orig_path, Some tmp_path) ->
-         let user_filepath : string option =
-           KB.Value.get Data.Patched_exe.filepath obj
-         in
-         let patched_exe_filepath : string =
-           Option.value user_filepath
-             ~default:(  (Filename.basename orig_path)
-                       ^ ".patched")
-         in
-         begin
-           Utils.cp tmp_path patched_exe_filepath;
-           Events.(send @@ 
-             Info (Printf.sprintf "Patched exe: %s\n " patched_exe_filepath));
-           Ok patched_exe_filepath
-         end
+        let user_filepath : string option =
+          KB.Value.get Data.Patched_exe.filepath obj
+        in
+        let patched_exe_filepath : string =
+          Option.value user_filepath
+            ~default:(  (Filename.basename orig_path)
+                        ^ ".patched")
+        in
+        begin
+          Utils.cp tmp_path patched_exe_filepath;
+          Events.(send @@
+                  Info (Printf.sprintf "Patched exe: %s\n " patched_exe_filepath));
+          Ok patched_exe_filepath
+        end
       | (None, _) ->
-         begin
+        begin
           let msg = "Missing filepath for the original exe" in
           let err = Errors.Problem (Errors.Other msg) in
           Events.(send @@ Info msg);
           Error err
-         end
+        end
       | (_, None) ->
         begin
           let msg = "No filepath for the temporary patched exe was computed" in
@@ -106,9 +106,9 @@ let run (config : Config.t) : (string, KB.Conflict.t) result =
     end
 
   (* Otherwise, error. *)
-  | Error e -> 
+  | Error e ->
     begin
       Events.(send @@ Info "An error occurred");
       Events.(send @@ Info (Format.asprintf "%a\n" KB.Conflict.pp e));
       Error e
-    end 
+    end

--- a/lib/src/utils.ml
+++ b/lib/src/utils.ml
@@ -24,20 +24,20 @@ let run_process_exn (command : string) (args : string list) : unit KB.t =
     Unix.open_process (String.concat " " (command :: args)) in
   let status = Unix.close_process (as_stdout, as_stdin) in
   match status with
-   | WEXITED 0 -> KB.return ()
-   | WEXITED 127 -> 
-     begin
-       let msg = Format.sprintf "'%s' not found in PATH" command in
-       Errors.fail (Errors.Command_not_found msg)
-     end
-   | WEXITED n -> 
-     begin
-       let msg = Format.sprintf "%s returned exit code: %d" command n in
-       Errors.fail (Errors.Exit_code msg)
-     end
-   | _ -> 
-     begin
-       let msg = 
-         Format.sprintf "%s exited with unknown return status" command in
-       Errors.fail (Errors.Unexpected_exit msg)
-     end
+  | WEXITED 0 -> KB.return ()
+  | WEXITED 127 ->
+    begin
+      let msg = Format.sprintf "'%s' not found in PATH" command in
+      Errors.fail (Errors.Command_not_found msg)
+    end
+  | WEXITED n ->
+    begin
+      let msg = Format.sprintf "%s returned exit code: %d" command n in
+      Errors.fail (Errors.Exit_code msg)
+    end
+  | _ ->
+    begin
+      let msg =
+        Format.sprintf "%s exited with unknown return status" command in
+      Errors.fail (Errors.Unexpected_exit msg)
+    end

--- a/lib/src/verbose.ml
+++ b/lib/src/verbose.ml
@@ -4,7 +4,7 @@ open !Core_kernel
 
 (* For configuring a verbose log. *)
 module type Config = sig
-  val with_colors : bool 
+  val with_colors : bool
 end
 
 (* The verbose log writes to stderr. *)

--- a/lib/src/verifier.ml
+++ b/lib/src/verifier.ml
@@ -49,9 +49,9 @@ let check_naive (orig_prog : Program.t) (patch_prog : Program.t)
   let postconds, hyps =
     Compare.compare_subs_smtlib ~smtlib_hyp ~smtlib_post in
 
-  let precond, _env_1, _env_2 = Compare.compare_subs 
-    ~postconds:[postconds] ~hyps:[hyps]
-    ~original:(orig_func, env_1) ~modified:(patch_func, env_2) in
+  let precond, _env_1, _env_2 = Compare.compare_subs
+      ~postconds:[postconds] ~hyps:[hyps]
+      ~original:(orig_func, env_1) ~modified:(patch_func, env_2) in
 
   let solver = Z3.Solver.mk_solver z3_ctx None in
   Precondition.check solver z3_ctx precond
@@ -88,12 +88,12 @@ let verify
   match status with
   | Z3.Solver.UNSATISFIABLE ->
     Events.(send @@
-      Info "Weakest-precondition analysis returned: correct");
+            Info "Weakest-precondition analysis returned: correct");
     Events.(send @@ Info "The patched binary is correct");
     KB.return Done
   | Z3.Solver.SATISFIABLE ->
     Events.(send @@
-      Info "Weakest-precondition analysis returned: incorrect");
+            Info "Weakest-precondition analysis returned: incorrect");
     Events.(send @@ Info "The patched binary is not correct");
     Events.(send @@ Info "For now, we'll pretend it is and move on");
     KB.return Done

--- a/lib/src/verifier.mli
+++ b/lib/src/verifier.mli
@@ -1,9 +1,9 @@
 (* Verifies the patched executable.
 
    This module is responsible for comparing the patched executable (produced
-   by the {!Patcher}) against the original executable, to determine if the 
-   patched executable is correct. 
-   
+   by the {!Patcher}) against the original executable, to determine if the
+   patched executable is correct.
+
    This module checks correctness by using CBAT to confirm whether a
    correctness property specified by the user holds of the patched executable
    relative to the original executable. *)

--- a/lib/src/vibes_ir.ml
+++ b/lib/src/vibes_ir.ml
@@ -18,18 +18,18 @@ let simple_var v = {
 type operand = Var of op_var | Const of Word.t | Label of Tid.t [@@deriving compare, equal]
 
 type shift = [
-| `ASR
-| `LSL
-| `LSR
-| `ROR
-| `RRX
+  | `ASR
+  | `LSL
+  | `LSR
+  | `ROR
+  | `RRX
 ] [@@deriving sexp, equal, compare]
 
 
 let op_var_exn (x : operand) : op_var =
-   match x with
-   | Var o -> o
-   | _ -> failwith "Expected op_var"
+  match x with
+  | Var o -> o
+  | _ -> failwith "Expected op_var"
 
 type insn = [Arm_types.insn | shift] [@@deriving sexp]
 
@@ -121,7 +121,7 @@ module Blk = struct
     let operation_operands =
       List.concat_map blk.operations
         ~f:(fun operation ->
-          operation.lhs @ operation.operands)
+            operation.lhs @ operation.operands)
     in
     blk.ins.lhs @ blk.outs.operands @ operation_operands
 
@@ -129,7 +129,7 @@ module Blk = struct
     let operation_operands =
       List.concat_map blk.operations
         ~f:(fun operation ->
-          operation.operands)
+            operation.operands)
     in
     blk.ins.operands @ blk.outs.operands @ operation_operands
 
@@ -137,41 +137,41 @@ module Blk = struct
     let operation_operands =
       List.concat_map blk.operations
         ~f:(fun operation ->
-          operation.lhs)
+            operation.lhs)
     in
     blk.ins.lhs @ blk.outs.lhs @ operation_operands
 
   let all_temps (blk : blk) : Var.Set.t =
     List.concat_map (all_operands blk)
       ~f:(fun op ->
-        match op with
-        | Const _ -> []
-        | Label _ -> []
-        | Var op -> op.temps) |>
-      Var.Set.of_list
+          match op with
+          | Const _ -> []
+          | Label _ -> []
+          | Var op -> op.temps) |>
+    Var.Set.of_list
 
   let definer_map (blk : blk) : op_var Var.Map.t =
     List.fold
       (all_lhs_operands blk |> var_operands)
       ~init:Var.Map.empty
       ~f:(fun acc operand ->
-        List.fold operand.temps
-          ~init:acc
-          ~f:(fun acc tmp ->
-            Var.Map.add_exn acc ~key:tmp ~data:operand))
+          List.fold operand.temps
+            ~init:acc
+            ~f:(fun acc tmp ->
+                Var.Map.add_exn acc ~key:tmp ~data:operand))
 
   let users_map (blk : blk) : (op_var list) Var.Map.t =
     List.fold (all_rhs_operands blk |> var_operands)
       ~init:Var.Map.empty
       ~f:(fun acc operand ->
-        List.fold operand.temps ~init:acc ~f:(fun acc temp ->
-            Var.Map.update acc temp
-              ~f:(fun mrandlist ->
-                match mrandlist with
-                | Some operandlist -> operand :: operandlist
-                | None -> [operand])
-          )
-      )
+          List.fold operand.temps ~init:acc ~f:(fun acc temp ->
+              Var.Map.update acc temp
+                ~f:(fun mrandlist ->
+                    match mrandlist with
+                    | Some operandlist -> operand :: operandlist
+                    | None -> [operand])
+            )
+        )
 
   let all_operations (blk : blk) : operation list = blk.ins :: ( blk.outs :: blk.operations)
 
@@ -184,14 +184,14 @@ module Blk = struct
     let alist =
       List.concat_map (all_operations blk)
         ~f:(fun operation ->
-          let rhs_operands =
-            List.map (var_operands operation.operands)
-              ~f:(fun op -> (op.id, operation))
-          in
-          let lhs_operands =
-            List.map (var_operands operation.lhs)
-              ~f:(fun op -> (op.id, operation)) in
-          lhs_operands @ rhs_operands)
+            let rhs_operands =
+              List.map (var_operands operation.operands)
+                ~f:(fun op -> (op.id, operation))
+            in
+            let lhs_operands =
+              List.map (var_operands operation.lhs)
+                ~f:(fun op -> (op.id, operation)) in
+            lhs_operands @ rhs_operands)
     in
     Var.Map.of_alist_exn alist
 
@@ -201,18 +201,18 @@ end
 let var_map_union_exn m1 m2 =
   Var.Map.merge m1 m2
     ~f:(fun ~key:_ ab ->
-      match ab with
-      | `Left a -> Some a
-      | `Right b -> Some b
-      | `Both(_ , _) -> failwith "Map has both keys")
+        match ab with
+        | `Left a -> Some a
+        | `Right b -> Some b
+        | `Both(_ , _) -> failwith "Map has both keys")
 
 let tid_map_union_exn m1 m2 =
   Tid.Map.merge m1 m2
     ~f:(fun ~key:_ ab ->
-      match ab with
-      | `Left a -> Some a
-      | `Right b -> Some b
-      | `Both(_ , _) -> failwith "Map has both keys")
+        match ab with
+        | `Left a -> Some a
+        | `Right b -> Some b
+        | `Both(_ , _) -> failwith "Map has both keys")
 
 let map_blks ~f (sub : t) : t =
   {blks = List.map ~f sub.blks; congruent = sub.congruent}
@@ -220,11 +220,11 @@ let map_blks ~f (sub : t) : t =
 let map_operations ~f (vir : t) : t =
   map_blks vir
     ~f:(fun b ->
-      { id = b.id;
-        operations = List.map ~f b.operations;
-        ins = f b.ins;
-        outs = f b.outs;
-        frequency = b.frequency })
+        { id = b.id;
+          operations = List.map ~f b.operations;
+          ins = f b.ins;
+          outs = f b.outs;
+          frequency = b.frequency })
 
 let map_op_vars ~f (vir : t) : t =
   let f2 o = match o with
@@ -242,13 +242,13 @@ let map_op_vars ~f (vir : t) : t =
     blks =
       List.map vir.blks
         ~f:(fun b ->
-          {
-            b with
-            operations = List.map ~f:apply_to_op b.operations;
-            ins = apply_to_op b.ins;
-            outs = apply_to_op b.outs;
-          }
-        );
+            {
+              b with
+              operations = List.map ~f:apply_to_op b.operations;
+              ins = apply_to_op b.ins;
+              outs = apply_to_op b.outs;
+            }
+          );
     congruent = List.map ~f:(Tuple2.map ~f:f) vir.congruent;
   }
 
@@ -256,63 +256,63 @@ let all_temps (sub : t) : Var.Set.t =
   List.fold sub.blks
     ~init:Var.Set.empty
     ~f:(fun acc blk ->
-      Var.Set.union acc (Blk.all_temps blk))
+        Var.Set.union acc (Blk.all_temps blk))
 
 let all_operands (sub : t) : Var.Set.t =
   List.concat_map sub.blks ~f:Blk.all_operands |>
-    var_operands |>
-    List.map ~f:(fun (o : op_var) -> o.id) |>
-    Var.Set.of_list
+  var_operands |>
+  List.map ~f:(fun (o : op_var) -> o.id) |>
+  Var.Set.of_list
 
 let definer_map (sub : t) : op_var Var.Map.t =
   List.fold sub.blks
     ~init:Var.Map.empty
     ~f:(fun acc blk ->
-      var_map_union_exn acc (Blk.definer_map blk))
+        var_map_union_exn acc (Blk.definer_map blk))
 
 
 let users_map (sub : t) : (op_var list) Var.Map.t =
   List.fold sub.blks
     ~init:Var.Map.empty
     ~f:(fun acc blk ->
-      let m = Blk.users_map blk in
-      Var.Map.merge acc m
-        ~f:(fun ~key:_ ab ->
-          match ab with
-          | `Left a -> Some a
-          | `Right b -> Some b
-          | `Both(a,b) -> Some (a @ b)))
+        let m = Blk.users_map blk in
+        Var.Map.merge acc m
+          ~f:(fun ~key:_ ab ->
+              match ab with
+              | `Left a -> Some a
+              | `Right b -> Some b
+              | `Both(a,b) -> Some (a @ b)))
 
 let temp_blk (sub : t) : Tid.t Var.Map.t =
   List.concat_map sub.blks
     ~f:(fun blk ->
-      List.map (Blk.all_temps blk |> Var.Set.to_list)
-        ~f:(fun t -> (t, blk.id))) |>
-    Var.Map.of_alist_exn
+        List.map (Blk.all_temps blk |> Var.Set.to_list)
+          ~f:(fun t -> (t, blk.id))) |>
+  Var.Map.of_alist_exn
 
 let operation_insns (sub : t) : (insn list) Tid.Map.t =
   List.fold sub.blks
     ~init:Tid.Map.empty
     ~f:(fun acc blk ->
-      tid_map_union_exn acc (Blk.operation_insn blk))
+        tid_map_union_exn acc (Blk.operation_insn blk))
 
 let operand_operation (sub : t) : operation Var.Map.t =
   List.fold sub.blks
     ~init:Var.Map.empty
     ~f:(fun acc blk ->
-      var_map_union_exn acc (Blk.operand_operation blk))
+        var_map_union_exn acc (Blk.operand_operation blk))
 
 let pretty_operand o =
   match o with
   | Var(o) ->
-     sprintf "%s : %s < %s"
-       (Var.to_string o.id)
-       (List.map ~f:Var.to_string o.temps |> String.concat ~sep:"::")
-       ((Option.map
-           ~f:(fun r ->
-             ARM.sexp_of_gpr_reg r |>
-               Ppx_sexp_conv_lib.Sexp.to_string) o.pre_assign) |>
-          Option.value ~default:"N/A")
+    sprintf "%s : %s < %s"
+      (Var.to_string o.id)
+      (List.map ~f:Var.to_string o.temps |> String.concat ~sep:"::")
+      ((Option.map
+          ~f:(fun r ->
+              ARM.sexp_of_gpr_reg r |>
+              Ppx_sexp_conv_lib.Sexp.to_string) o.pre_assign) |>
+       Option.value ~default:"N/A")
   | Const(c) -> Word.to_string c
   | Label(l) -> Tid.to_string l
 
@@ -339,6 +339,6 @@ let pretty_ir (vir : t) : string =
 let dummy_reg_alloc t =
   map_op_vars t
     ~f:(fun v ->
-      match v.pre_assign with
-      | Some _ -> v
-      | None -> {v with pre_assign = Some `R0})
+        match v.pre_assign with
+        | Some _ -> v
+        | None -> {v with pre_assign = Some `R0})

--- a/lib/src/vibes_ir.mli
+++ b/lib/src/vibes_ir.mli
@@ -85,7 +85,7 @@ type blk = {
 val simple_blk : tid -> operation list -> blk
 
 (** The [vibes_ir] type has a list of blocks and a set of operands
-   which are congruent.  *)
+    which are congruent.  *)
 type t = {
   blks : blk list;
   congruent : (op_var * op_var) list
@@ -109,16 +109,16 @@ val all_temps : t -> Var.Set.t
 val all_operands : t -> Var.Set.t
 
 (** [definer_map] takes a subroutine and builds a Map from all
-   temporaries to the unique lhs operand where that temporary is
-   defined. *)
+    temporaries to the unique lhs operand where that temporary is
+    defined. *)
 val definer_map : t -> op_var Var.Map.t
 
 (** [users_map] takes a subroutine and builds a Map from all
-   temporaries to the operands that may use that temporary. *)
+    temporaries to the operands that may use that temporary. *)
 val users_map : t -> (op_var list) Var.Map.t
 
 (** [temp_blk] builds a Map from temporaries to the unique block in
-   which they are defined and used. *)
+    which they are defined and used. *)
 val temp_blk : t -> Tid.t Var.Map.t
 
 val operation_insns : t -> insn list Tid.Map.t
@@ -128,5 +128,5 @@ val pretty_ir : t -> string
 val op_var_exn : operand -> op_var
 
 (** Populate the [pre_assign] field with [`R0] if it is not already
-   assigned. Useful for testing purposes. *)
+    assigned. Useful for testing purposes. *)
 val dummy_reg_alloc : t -> t

--- a/lib/tests/helpers.ml
+++ b/lib/tests/helpers.ml
@@ -83,8 +83,8 @@ let assert_property ~cmp ?p_res ?p_expected
     end
   | Error problem ->
     let msg = Format.asprintf
-      "@[<v 4>expected a value, but got an error:@,@[%a@]@]"
-      KB.Conflict.pp problem
+        "@[<v 4>expected a value, but got an error:@,@[%a@]@]"
+        KB.Conflict.pp problem
     in
     assert_bool msg false
 
@@ -120,10 +120,10 @@ let assert_error ?printer property expected result : unit =
   | Error problem ->
     begin
       let msg = Format.asprintf "@[<v 4>%s:@,@[%s@]@]@.@[<v 4>%s:@,@[%s@]@]"
-        "expected error"
-        (Format.asprintf "%a" KB.Conflict.pp expected)
-        "but got this error"
-        (Format.asprintf "%a" KB.Conflict.pp problem)
+          "expected error"
+          (Format.asprintf "%a" KB.Conflict.pp expected)
+          "but got this error"
+          (Format.asprintf "%a" KB.Conflict.pp problem)
       in
       assert_bool msg String.((KB.Conflict.to_string problem) = (KB.Conflict.to_string expected))
     end
@@ -159,10 +159,10 @@ let print_bil bil = Format.asprintf "%a" Bil.pp bil
 
 (* A verifier function for testing. It always returns unsat. *)
 let verify_unsat (_ : Program.t) (_ : Program.t) (_ : string) (_ : Sexp.t)
-    : Z3.Solver.status =
+  : Z3.Solver.status =
   Z3.Solver.UNSATISFIABLE
 
 (* A verifier function for testing. It always returns sat. *)
 let verify_sat (_ : Program.t) (_ : Program.t) (_ : string) (_ : Sexp.t)
-    : Z3.Solver.status =
+  : Z3.Solver.status =
   Z3.Solver.SATISFIABLE

--- a/lib/tests/test.ml
+++ b/lib/tests/test.ml
@@ -1,14 +1,14 @@
 open OUnit2
 
 let suite = "Full suite" >::: [
-  "Exe_ingester" >::: Test_exe_ingester.suite;
-  "Patch_ingester" >::: Test_patch_ingester.suite;
-  "Compiler" >::: Test_compiler.suite;
-  "Vibes_ir" >::: Test_vibes_ir.suite;
-  "Minizinc" >::: Test_minizinc.suite;
-  "Patcher" >::: Test_patcher.suite;
-  "Verifier" >::: Test_verifier.suite;
-  "Arm_gen" >::: Test_arm.suite;
-]
+    "Exe_ingester" >::: Test_exe_ingester.suite;
+    "Patch_ingester" >::: Test_patch_ingester.suite;
+    "Compiler" >::: Test_compiler.suite;
+    "Vibes_ir" >::: Test_vibes_ir.suite;
+    "Minizinc" >::: Test_minizinc.suite;
+    "Patcher" >::: Test_patcher.suite;
+    "Verifier" >::: Test_verifier.suite;
+    "Arm_gen" >::: Test_arm.suite;
+  ]
 
 let _ = run_test_tt_main suite

--- a/lib/tests/test_arm.ml
+++ b/lib/tests/test_arm.ml
@@ -196,9 +196,9 @@ let test_ir (_ : test_ctxt) (v : unit eff) (expected : string list) : unit =
     begin
       match input, expected with
       | Some input, Some expected ->
-         let pairs = List.zip_exn expected input in
-         let matches = List.map pairs ~f:(fun (pat, str) -> Str.string_match pat str 0) in
-         List.for_all ~f:(fun b -> b) matches
+        let pairs = List.zip_exn expected input in
+        let matches = List.map pairs ~f:(fun (pat, str) -> Str.string_match pat str 0) in
+        List.for_all ~f:(fun b -> b) matches
       | _ -> false
     end
   in

--- a/lib/tests/test_exe_ingester.ml
+++ b/lib/tests/test_exe_ingester.ml
@@ -76,5 +76,5 @@ let suite = [
   "Test Exe_ingester.ingest: stashes address size" >:: test_ingest_addr_size;
   "Test Exe_ingester.ingest: stashes lifted program" >:: test_ingest_prog;
   "Test Exe_ingester.ingest: no original exe filepath" >::
-    test_ingest_with_no_exe_filepath;
+  test_ingest_with_no_exe_filepath;
 ]

--- a/lib/tests/test_patch_ingester.ml
+++ b/lib/tests/test_patch_ingester.ml
@@ -73,7 +73,7 @@ let test_ingest_with_no_addr_size (_ : test_ctxt) : unit =
 let suite = [
   "Test Patch_ingester.ingest" >:: test_ingest;
   "Test Patch_ingester.ingest: no patch" >::
-    test_ingest_with_no_patch;
+  test_ingest_with_no_patch;
   "Test Patch_ingester.ingest: no address size" >::
-    test_ingest_with_no_addr_size;
+  test_ingest_with_no_addr_size;
 ]

--- a/lib/tests/test_verifier.ml
+++ b/lib/tests/test_verifier.ml
@@ -16,7 +16,7 @@ module Test_data = struct
   let cls : (cls, unit) KB.cls = KB.Class.declare ~package name ()
   let result : (cls, string) KB.slot =
     KB.Class.property ~package cls
-    "test-result-for-verifier" KB.Domain.string
+      "test-result-for-verifier" KB.Domain.string
 end
 
 (* Test that [Verifier.verify] works as expected for Z3 [UNSAT]. *)
@@ -196,9 +196,9 @@ let suite = [
   "Test Verifier.verify: UNSAT" >:: test_verify_unsat;
   "Test Verifier.verify: SAT" >:: test_verify_sat;
   "Test Verifier.verify: no lifted original exe" >::
-    test_verify_with_no_original_exe_prog;
+  test_verify_with_no_original_exe_prog;
   "Test Verifier.verify: no patched exe filepath" >::
-    test_verify_with_no_patched_exe;
+  test_verify_with_no_patched_exe;
   "Test Verifier.verify: no correctness property" >::
-    test_verify_with_no_property;
+  test_verify_with_no_property;
 ]


### PR DESCRIPTION
Should be a no-op from a semantic perspective.