### PR TITLE
Philip/jmp overflow

### DIFF
--- a/lib/src/data.ml
+++ b/lib/src/data.ml
@@ -254,11 +254,7 @@ module Verifier = struct
 end
 
 (* Create an object of this class. *)
-<<<<<<< HEAD
 let create_patches (ps : Config.patch list) : Patch_set.t KB.t =
-=======
-let create_patches (ps : Config.patch list) : PatchSet.t KB.t =
->>>>>>> 2a432ac... This adds support for multiple patch fragments
   let create_patch (p : Config.patch) : Patch.t KB.t =
     KB.Object.create Patch.patch >>= fun obj ->
     Patch.set_patch_name obj (Some p.patch_name) >>= fun () ->
@@ -266,11 +262,7 @@ let create_patches (ps : Config.patch list) : PatchSet.t KB.t =
     Patch.set_patch_size obj (Some p.patch_size) >>= fun () ->
     KB.return obj
   in
-<<<<<<< HEAD
   KB.all (List.map ~f:create_patch ps) >>| Patch_set.of_list
-=======
-  KB.all (List.map ~f:create_patch ps) >>| PatchSet.of_list
->>>>>>> 2a432ac... This adds support for multiple patch fragments
 
 let create (config : Config.t) : t KB.t =
   let exe = Config.exe config in
@@ -286,11 +278,7 @@ let create (config : Config.t) : t KB.t =
   KB.return obj
 
 (* Create a fresh version of an object. *)
-<<<<<<< HEAD
 let fresh_patches (patches : Patch_set.t) : Patch_set.t KB.t =
-=======
-let fresh_patches (patches : PatchSet.t) : PatchSet.t KB.t =
->>>>>>> 2a432ac... This adds support for multiple patch fragments
   let fresh_patch (patch : Patch.t) : Patch.t KB.t =
     Patch.get_patch_name patch >>= fun name ->
     Patch.get_patch_point patch >>= fun point ->
@@ -303,13 +291,8 @@ let fresh_patches (patches : PatchSet.t) : PatchSet.t KB.t =
     Patch.set_bil patch' bil >>= fun () ->
     KB.return patch'
   in
-<<<<<<< HEAD
   KB.all (List.map ~f:fresh_patch (Patch_set.to_list patches)) >>=
     fun ps' -> KB.return (Patch_set.of_list ps')
-=======
-  KB.all (List.map ~f:fresh_patch (PatchSet.to_list patches)) >>=
-    fun ps' -> KB.return (PatchSet.of_list ps')
->>>>>>> 2a432ac... This adds support for multiple patch fragments
 
 let fresh ~property:(property : Sexp.t) (obj : t) : t KB.t =
   KB.Object.create cls >>= fun obj' ->

--- a/lib/src/data.mli
+++ b/lib/src/data.mli
@@ -90,30 +90,17 @@ module Original_exe : sig
 end
 
 (* Sets of patches *)
-<<<<<<< HEAD
 module Patch_set : Set.S with type Elt.t = Patch.t
-=======
-module PatchSet : Set.S with type Elt.t = Patch.t
->>>>>>> 2a432ac... This adds support for multiple patch fragments
 
 (* Properties pertaining to the patched executable *)
 module Patched_exe : sig
 
-<<<<<<< HEAD
   val patches : (cls, Patch_set.t) KB.slot
   val filepath : (cls, string option) KB.slot
   val tmp_filepath : (cls, string option) KB.slot
 
   val set_patches : t -> Patch_set.t -> unit KB.t
   val get_patches : t -> Patch_set.t KB.t
-=======
-  val patches : (cls, PatchSet.t) KB.slot
-  val filepath : (cls, string option) KB.slot
-  val tmp_filepath : (cls, string option) KB.slot
-
-  val set_patches : t -> PatchSet.t -> unit KB.t
-  val get_patches : t -> PatchSet.t KB.t
->>>>>>> 2a432ac... This adds support for multiple patch fragments
 
   val set_filepath : t -> string option -> unit KB.t
   val get_filepath : t -> string option KB.t

--- a/lib/tests/test_patcher.ml
+++ b/lib/tests/test_patcher.ml
@@ -9,7 +9,7 @@ module H = Helpers
 
 
 (* A dummy patcher, that returns a fixed filename. *)
-let patcher _ _ _ = KB.return H.patched_exe
+let patcher _ _ _ _ = KB.return H.patched_exe
 
 (* Test that [Patcher.patch] works as expected. *)
 let test_patch (_ : test_ctxt) : unit =
@@ -22,13 +22,10 @@ let test_patch (_ : test_ctxt) : unit =
     Data.Original_exe.set_filepath obj (Some H.original_exe) >>= fun _ ->
     KB.Object.create Data.Patch.patch >>= fun patch ->
     Data.Patch.set_patch_point patch (Some H.patch_point) >>= fun _ ->
+    Data.Patch.set_patch_size patch (Some 1024) >>= fun _ ->
     Data.Patch.set_assembly patch (Some H.assembly) >>= fun _ ->
     Data.Patched_exe.set_patches obj
-<<<<<<< HEAD
       (Data.Patch_set.singleton patch) >>= fun _ ->
-=======
-      (Data.PatchSet.singleton patch) >>= fun _ ->
->>>>>>> 2a432ac... This adds support for multiple patch fragments
 
     (* Now run the patcher. *)
     Patcher.patch obj ~patcher:patcher >>= fun _ ->
@@ -71,12 +68,9 @@ let test_patch_with_no_patch_point (_ : test_ctxt) : unit =
     H.obj () >>= fun obj ->
     Data.Original_exe.set_filepath obj (Some H.original_exe) >>= fun _ ->
     KB.Object.create Data.Patch.patch >>= fun patch ->
+    Data.Patch.set_patch_size patch (Some 1024) >>= fun _ ->
     Data.Patched_exe.set_patches obj
-<<<<<<< HEAD
       (Data.Patch_set.singleton patch) >>= fun _ ->
-=======
-      (Data.PatchSet.singleton patch) >>= fun _ ->
->>>>>>> 2a432ac... This adds support for multiple patch fragments
     (* Now run the patcher. *)
     Patcher.patch obj >>= fun _ ->
     KB.return obj
@@ -100,6 +94,7 @@ let test_patch_with_no_assembly (_ : test_ctxt) : unit =
     Data.Original_exe.set_filepath obj (Some H.original_exe) >>= fun _ ->
     KB.Object.create Data.Patch.patch >>= fun patch ->
     Data.Patch.set_patch_point patch (Some H.patch_point) >>= fun _ ->
+    Data.Patch.set_patch_size patch (Some 1024) >>= fun _ ->
     Data.Patched_exe.set_patches obj
       (Data.Patch_set.singleton patch) >>= fun _ ->
 


### PR DESCRIPTION
Not necessarily ready to merge, but is functional.

This pull request adds in the capability of the patcher to use an overflow `vibes_dummy` region if the patch does not fit in the original area. The `vibes_dummy` region needs to be precompiled in at the moment.
There needs to be at least space for a single instruction at the patch target location. This could also be fixed later.

