### PR TITLE
Add helpful errors for when the function to verify is missing

### DIFF
--- a/bap-vibes/src/toplevel_error.ml
+++ b/bap-vibes/src/toplevel_error.ml
@@ -8,6 +8,8 @@ type t =
   | WP_result_unknown of string
   | Max_tries of int
   | No_value_in_KB of string
+  | Missing_func_orig of string
+  | Missing_func_patched of string
   | KB_error of Kb_error.t
   | Other of string
 
@@ -18,6 +20,14 @@ let pp ppf (e : t) =
     | WP_result_unknown s -> s
     | Max_tries n -> Format.sprintf "Tried %d times. Giving up" n
     | No_value_in_KB s -> s
+    | Missing_func_orig s ->
+       Format.sprintf
+         "Function %s missing from original binary at verification time."
+         s
+    | Missing_func_patched s ->
+       Format.sprintf
+         "Function %s missing from patched binary at verification time."
+         s
     | KB_error e -> Format.asprintf "%a" Kb_error.pp e
     | Other s -> s
   in

--- a/bap-vibes/src/toplevel_error.mli
+++ b/bap-vibes/src/toplevel_error.mli
@@ -12,6 +12,8 @@ type t =
   | WP_result_unknown of string
   | Max_tries of int
   | No_value_in_KB of string
+  | Missing_func_orig of string
+  | Missing_func_patched of string
   | KB_error of Kb_error.t
   | Other of string
 

--- a/bap-vibes/src/utils.ml
+++ b/bap-vibes/src/utils.ml
@@ -66,6 +66,6 @@ let load_exe (filename : string)
       Error (Toplevel_error.Failed_to_load_proj msg)
     end
 
-let get_func (prog : Program.t) (name : string) : Sub.t =
+let get_func (prog : Program.t) (name : string) : Sub.t option =
   let subs = Term.enum sub_t prog in
-  Seq.find_exn ~f:(fun s -> String.equal (Sub.name s) name) subs
+  Seq.find ~f:(fun s -> String.equal (Sub.name s) name) subs

--- a/bap-vibes/src/utils.mli
+++ b/bap-vibes/src/utils.mli
@@ -10,12 +10,12 @@ val cp : string -> string -> unit
 (** [run_process command args] runs [command] with [args] *)
 val run_process : string -> string list -> (unit, Kb_error.t) Result.t
 
-(** [lift_kb_result] transforms a computation in the Result.t monad 
+(** [lift_kb_result] transforms a computation in the Result.t monad
     into the KB.t monad. *)
 val lift_kb_result : ('a, Kb_error.t) Result.t -> 'a KB.t
 
 (** [load_exe "/path/to/exe"] loads /path/to/exe into BAP. *)
 val load_exe : string -> (project * Program.t, Toplevel_error.t) result
 
-(** [get_sub prog "main"] returns the function ["main"] in [prog]. *)
-val get_func : Program.t -> string -> Sub.t
+(** [get_sub prog "main"] returns the function ["main"] in [prog], if present. *)
+val get_func : Program.t -> string -> Sub.t option


### PR DESCRIPTION
This can happen, for example, if you typo the function name in the config file.
The old behavior  was an uncaught exception in core_kernel, which was a 
little confusing.