### PR TITLE
removes opam from build scripts, improves portability

### DIFF
--- a/bap-vibes/Makefile
+++ b/bap-vibes/Makefile
@@ -27,7 +27,7 @@ INTG_TEST_SRC_FILES := \
 .DEFAULT_GOAL := all
 
 .PHONY: all
-all: 
+all:
 	$(MAKE) clean
 	$(MAKE) build
 
@@ -37,7 +37,7 @@ all:
 #####################################################
 
 .PHONY: clean
-clean: 
+clean:
 	dune clean
 
 
@@ -46,7 +46,7 @@ clean:
 #####################################################
 
 build: $(LIB_SRC_FILES)
-	dune build -p $(LIB)
+	dune build -p $(LIB) @install
 	@echo "" # Force a newline in terminal output
 
 
@@ -56,11 +56,11 @@ build: $(LIB_SRC_FILES)
 
 .PHONY: install
 install:
-	opam install .
+	dune install
 
 .PHONY: uninstall
 uninstall:
-	opam remove .
+	dune uninstall
 
 
 #####################################################

--- a/bap-vibes/bap-vibes.opam
+++ b/bap-vibes/bap-vibes.opam
@@ -21,6 +21,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_jane"
   "z3"
+  "result"
 ]
 build: [
   [make]

--- a/bap-vibes/src/utils.ml
+++ b/bap-vibes/src/utils.ml
@@ -1,11 +1,13 @@
 (* Implements {!Utils}. *)
 
+open Result
 open Bap.Std
 open Bap_knowledge
 open Bap_core_theory
 open Bap_demangle.Std
 module KB = Knowledge
 open KB.Let
+
 
 let cp (src_filepath : string) (dst_filepath : string) : unit =
   let buffer_size = 1026 in
@@ -24,15 +26,15 @@ let cp (src_filepath : string) (dst_filepath : string) : unit =
   Unix.close fd_out
 
 (* [lift_kb] lifts the Result monad to the KB monad *)
-let lift_kb_result (x : ('a, Kb_error.t) Result.t) : 'a KB.t =
+let lift_kb_result (x : ('a, Kb_error.t) result) : 'a KB.t =
   match x with
   | Ok x -> KB.return x
   | Error e -> Kb_error.fail e
 
 let run_process (command : string) (args : string list)
-    : (unit, Kb_error.t) Result.t =
+  : (unit, Kb_error.t) result =
   let (as_stdout, as_stdin) =
-  Unix.open_process (String.concat " "  (command :: args)) in
+    Unix.open_process (String.concat " "  (command :: args)) in
   let status = Unix.close_process (as_stdout, as_stdin) in
   match status with
   | WEXITED 0 -> Ok ()
@@ -54,7 +56,7 @@ let run_process (command : string) (args : string list)
     end
 
 let load_exe (filename : string)
-    : (project * Program.t, Toplevel_error.t) result =
+  : (project * Program.t, Toplevel_error.t) result =
   let input = Project.Input.file ~loader:"llvm" ~filename in
   match Project.create input ~package:filename with
   | Ok proj ->

--- a/bap-vibes/src/utils.mli
+++ b/bap-vibes/src/utils.mli
@@ -1,5 +1,6 @@
 (** Common utilities. *)
 
+open Result
 open Bap.Std
 open Bap_knowledge
 open Bap_core_theory
@@ -9,11 +10,11 @@ module KB = Knowledge
 val cp : string -> string -> unit
 
 (** [run_process command args] runs [command] with [args] *)
-val run_process : string -> string list -> (unit, Kb_error.t) Result.t
+val run_process : string -> string list -> (unit, Kb_error.t) result
 
 (** [lift_kb_result] transforms a computation in the Result.t monad
     into the KB.t monad. *)
-val lift_kb_result : ('a, Kb_error.t) Result.t -> 'a KB.t
+val lift_kb_result : ('a, Kb_error.t) result -> 'a KB.t
 
 (** [load_exe "/path/to/exe"] loads /path/to/exe into BAP. *)
 val load_exe : string -> (project * Program.t, Toplevel_error.t) result
@@ -22,12 +23,12 @@ val load_exe : string -> (project * Program.t, Toplevel_error.t) result
 val get_func : Program.t -> string -> Sub.t option
 
 (** [get_lang patch] returns the language associated with the
-   patch in the current binary under scutiny, at the location
-   indicated at the patch. *)
+    patch in the current binary under scutiny, at the location
+    indicated at the patch. *)
 val get_lang : filename:string -> addr_size:int -> addr:Bitvec.t -> Theory.language KB.t
 
 
 (** [get_lang patch] returns the target associated with the
-   patch in the current binary under scutiny, at the location
-   indicated at the patch. *)
+    patch in the current binary under scutiny, at the location
+    indicated at the patch. *)
 val get_target : filename:string -> addr_size:int -> addr:Bitvec.t -> Theory.target KB.t


### PR DESCRIPTION
- uses `dune install` instead of `opam install`
- adds `result` as a dependency to enable build on older version of OCaml