### PR TITLE
Refactor to use ppx_deriving_yojson

### DIFF
--- a/bap-vibes/src/config.mli
+++ b/bap-vibes/src/config.mli
@@ -8,6 +8,10 @@ type patch
 (** A type to represent a configuration record. *)
 type t
 
+(** [of_yojson obj] parses a yojson object to type t *)
+val t_of_yojson : exe:string -> patched_exe_filepath:string option ->
+    Yojson.Safe.t -> (t, string) result
+
 (** [patch_name p] returns the name of the patch [p]. *)
 val patch_name : patch -> string
 

--- a/bap-vibes/src/constants.ml
+++ b/bap-vibes/src/constants.ml
@@ -3,3 +3,4 @@
 let relative_patch_placement = "relative_patch_placement"
 let patch_start_label = "patch_start_label"
 let patch_location = "patch_location"
+let default_minizinc_model_filepath = "~/.vibes/model.mzn"

--- a/bap-vibes/src/constants.mli
+++ b/bap-vibes/src/constants.mli
@@ -13,3 +13,6 @@ val patch_start_label : string
 (** [patch_location] A variable set in the assembly file with the the file
     offset in the binary at which the patch will be placed. *)
 val patch_location : string
+
+(** [default_minizinc_model_filepath] is a path to the default minizinc model file *)
+val default_minizinc_model_filepath : string

--- a/plugin/lib/vibes_plugin_constants.ml
+++ b/plugin/lib/vibes_plugin_constants.ml
@@ -1,1 +1,0 @@
-let minizinc_model_filepath = "~/.vibes/model.mzn"

--- a/plugin/lib/vibes_plugin_parameters.ml
+++ b/plugin/lib/vibes_plugin_parameters.ml
@@ -12,135 +12,12 @@ module Err = Monad.Result.Make (Errors) (Monad.Ident)
 open Err.Syntax
 type error = Errors.t Err.error
 
-(* Get the default minizinc model filepath. *)
-let minizinc_model_filepath = Vibes_plugin_constants.minizinc_model_filepath
-
 (* Error if a string is empty. *)
 let is_not_empty (value : string) (e : Errors.t)
     : (string, error) Stdlib.result =
   match String.length value with
   | 0 -> Err.fail e
   | _ -> Err.return value
-
-(* Extract the patch name and check it is non-empty string. *)
-let validate_patch_name (obj : Json.t) : (string, error) Stdlib.result =
-  match Json.Util.member "patch-name" obj with
-  | `String s ->
-     if String.length s = 0 then Err.fail Errors.Missing_patch_name
-     else Err.return s
-  | _ -> Err.fail Errors.Missing_patch_name
-
-(* Extract the patch code, check it's a non-empty string, and parse
-   into a [Sexp.t list] (it should be a valid S-expression). *)
-let validate_patch_code (nm : string) (obj : Json.t)
-    : (Sexp.t list, error) Stdlib.result =
-  match Json.Util.member "patch-code" obj with
-  | `String s ->
-    begin
-     if String.length s = 0 then Err.fail Errors.Missing_patch_code
-     else 
-       begin
-         try Err.return (Sexp.scan_sexps (Lexing.from_string s))
-         with _ -> 
-           let msg =
-             "Code for patch '" ^ nm ^ "' is not a valid S-expression" in
-           Err.fail (Errors.Invalid_patch_code msg)
-       end
-    end
-  | _ -> Err.fail Errors.Missing_patch_code
-
-(* Extract the patch point field and parse the hex string into a bitvector, or
-   error. *)
-let validate_patch_point (obj : Json.t) : (Bitvec.t, error) Stdlib.result =
-  match Json.Util.member "patch-point" obj with
-  | `String s ->
-     begin
-       try
-         Err.return (Bitvec.of_string s)
-       with Invalid_argument _ ->
-         let msg = Format.sprintf "Invalid hex string: %s" s in
-         Err.fail (Errors.Invalid_hex msg)
-     end
-  | _ -> Err.fail Errors.Missing_patch_point
-
-(* Extract the patch size integer, or error. *)
-let validate_patch_size (obj : Json.t) : (int, error) Stdlib.result =
-  match Json.Util.member "patch-size" obj with
-  | `Int i -> Err.return i
-  | _ -> Err.fail Errors.Missing_size
-
-(* Validate a specific patch fragment within the list, or error *)
-let validate_patch (obj : Json.t) 
-    : (Vibes_config.patch, error) Stdlib.result =
-  validate_patch_name obj >>= fun patch_name ->
-  validate_patch_code patch_name obj >>= fun patch_code ->
-  validate_patch_point obj >>= fun patch_point ->
-  validate_patch_size obj >>= fun patch_size ->
-  let p = Vibes_config.create_patch
-    ~patch_name ~patch_code ~patch_point ~patch_size in
-  Err.return p
-
-(* Extract and validate the patch fragment list, or error. *)
-let validate_patches (obj : Json.t)
-    : (Vibes_config.patch list, error) Stdlib.result =
-  match Json.Util.member "patches" obj with
-  | `List ps -> Err.all (List.map ~f:validate_patch ps)
-  | _ -> Err.fail Errors.Missing_patches
-
-(* Extract and validate the name of the function to verify. *)
-let validate_func (obj : Json.t) : (string, error) Stdlib.result =
-  match Json.Util.member "func" obj with
-  | `String s ->
-    begin
-      if (String.length s) > 0 then Err.return s
-      else Err.fail Errors.Missing_func
-    end
-  | _ -> Err.fail Errors.Missing_func
-
-(* Extract the property field string and parse it into an S-expression, or
-   error. *)
-let validate_property (obj : Json.t) : (Sexp.t, error) Stdlib.result =
-  match Json.Util.member "property" obj with
-  | `String s ->
-     begin
-       try
-         Err.return (Sexp.of_string s)
-       with Failure _ ->
-         let msg = Format.sprintf "Invalid S-expression: %s" s in
-         Err.fail (Errors.Invalid_property msg)
-     end
-  | _ -> Err.fail Errors.Missing_property
-
-(* Extract the max-tries value, and make sure it's an [int] (if provided). *)
-let validate_max_tries (obj : Json.t) : (int option, error) Stdlib.result =
-  match Json.Util.member "max-tries" obj with
-  | `Int i -> Err.return (Some i)
-  | `Null -> Err.return None
-  | _ -> Err.fail Errors.Invalid_max_tries
-
-(* Extract the minizinc model filepathi value (or use the default), and make
-   sure the file really exists. *)
-let validate_minizinc_model_filepath (obj : Json.t)
-    : (string, error) Stdlib.result = 
-  match Json.Util.member "minizinc-model" obj with
-  | `String s ->
-    begin
-      if (String.length s) > 0 then
-        begin
-          let realpath = Vibes_plugin_utils.realpath s in
-          match realpath with
-          | Ok path -> Err.return path
-          | Error e -> Err.fail e
-        end
-      else Err.fail (Errors.Missing_minizinc_model_filepath)
-    end
-  | _ ->
-    begin
-      let realpath = Vibes_plugin_utils.realpath minizinc_model_filepath in
-      match realpath with
-      | Ok path -> Err.return path
-      | Error e -> Err.fail e
-    end
 
 (* Parse the user-provided JSON config file into a Yojson.Safe.t *)
 let parse_json (config_filepath : string) : (Json.t, error) Stdlib.result =
@@ -154,13 +31,6 @@ let create ~exe:(exe : string) ~config_filepath:(config_filepath : string)
     : (Vibes_config.t, error) result =
   is_not_empty exe Errors.Missing_exe >>= fun exe ->
   parse_json config_filepath >>= fun config_json ->
-  validate_patches config_json >>= fun patches ->
-  validate_func config_json >>= fun func ->
-  validate_property config_json >>= fun property ->
-  validate_max_tries config_json >>= fun max_tries ->
-  validate_minizinc_model_filepath config_json >>=
-    fun minizinc_model_filepath ->
-  let result = Vibes_config.create 
-    ~exe ~patches ~func ~property ~patched_exe_filepath ~max_tries
-    ~minizinc_model_filepath in
-  Ok result
+  match Vibes_config.t_of_yojson ~exe ~patched_exe_filepath config_json with
+    | Ok config -> Err.return config
+    | Error msg -> Err.fail (Errors.Config_not_parsed msg)


### PR DESCRIPTION
For discussion:

In order to use ppx_deriving_yojson, I pulled back some pieces of the parsing code from the plugin into config.ml. Deriving yojson in my opinion reduces boilerplate and makes it easier to modify the config datatype, which we will do shortly, at the expense of inferior error messages.

This change is not a strict improvement over the state of affairs previously but in my estimation is worth it.

There is still some further reduction possible.

We could also derive `to_yojson` to replace possibly some of the `Config.t` pretty printers
