### PR TITLE
Create a null tid when we're creating a block, to avoid a BAP bug.

### DIFF
--- a/bap-vibes/src/patch_ingester.ml
+++ b/bap-vibes/src/patch_ingester.ml
@@ -227,8 +227,7 @@ module CoreParser (Core : Theory.Core) = struct
          List.fold_right ~init:(perform Effect.Sort.bot) ~f:seq data
        in
        let* ctrl_blk = parse_ctrl st ctrl_sexp in
-       let l = KB.Object.null Theory.Program.cls in
-       blk l data_blk ctrl_blk
+       blk Theory.Label.null data_blk ctrl_blk
 
 end
 


### PR DESCRIPTION
We'll merge this when the CI Docker catches up with the current testing branch, which @ivg seemed to say would be soon.