### PR TITLE
Exclude R7 from gpr in arm_selector.ml

### DIFF
--- a/bap-vibes/src/arm_selector.ml
+++ b/bap-vibes/src/arm_selector.ml
@@ -75,7 +75,9 @@ let gpr (tgt : Theory.target) (lang : Theory.language) =
   let maybe_reify v =
     let v = Var.reify v in
     let name = Var.name v in
-    if String.(is_prefix name ~prefix:"R") then
+    if String.(is_prefix name ~prefix:"R") &&
+       not ((is_thumb lang) && String.(equal name "R7"))
+    then
       Some v
     else None
   in
@@ -87,7 +89,7 @@ let preassign_var
     (pre : var option)
     (v : var)
   : var option =
-  if String.(Var.name v = "FP") then
+  if String.(Var.name v = "__Vibes_tmp_FP") then
     begin
       (* We assign R11 as the pre-assigned FP register on ARM, and R7
          for Thumb, keeping in line with the ABI (as far as i can
@@ -99,7 +101,7 @@ let preassign_var
         Some (Var.create ~is_virtual:false ~fresh:false "R11" (Var.typ v))
     end
     (* FIXME: preassign all non-virtual variables? (or just the ones in tgt.regs?) *)
-  else if String.(Var.name v = "PC") then
+  else if String.(Var.name v = "__Vibes_tmp_PC") then
     Some (Var.create ~is_virtual:false ~fresh:false "PC" (Var.typ v))
   else
     pre


### PR DESCRIPTION
@Cody unit tests failing on `test_parse_c.ml`...maybe you should pull it and run them to see if you understand what's happening? Here's a snippet of some of the errors:

```
File "tests/unit/test_parse_c.ml", line 32, characters 1-1:
Error: Full suite:8:C Parser:3:Test ite (in the code).

expected: 
but got: {
     if (cond_expr) {
      bap:call(l1)
     } else {
       bap:call(l2)
      }
     }
------------------------------------------------------------------------------
==============================================================================
Error: Full suite:8:C Parser:2:Test seq.

File "/srv/VIBES/bap-vibes/_build/oUnit-Full suite-06054b78ae6e#01.log", line 77, characters 1-1:
Error: Full suite:8:C Parser:2:Test seq (in the log).

File "tests/unit/test_parse_c.ml", line 32, characters 1-1:
Error: Full suite:8:C Parser:2:Test seq (in the code).

expected:  but got: { x := y y := z }
------------------------------------------------------------------------------
==============================================================================
Error: Full suite:8:C Parser:1:Test assignment.

File "/srv/VIBES/bap-vibes/_build/oUnit-Full suite-06054b78ae6e#01.log", line 59, characters 1-1:
Error: Full suite:8:C Parser:1:Test assignment (in the log).

File "tests/unit/test_parse_c.ml", line 32, characters 1-1:
Error: Full suite:8:C Parser:1:Test assignment (in the code).

expected:  but got: { x := y }
------------------------------------------------------------------------------
==============================================================================
Error: Full suite:8:C Parser:0:Test vardecls.

File "/srv/VIBES/bap-vibes/_build/oUnit-Full suite-06054b78ae6e#01.log", line 41, characters 1-1:
Error: Full suite:8:C Parser:0:Test vardecls (in the log).

File "tests/unit/test_parse_c.ml", line 32, characters 1-1:
Error: Full suite:8:C Parser:0:Test vardecls (in the code).

expected:  but got: (())
------------------------------------------------------------------------------
```