### PR TITLE
Simpler slack reporting for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ before you run this script.
 
 To run the script, from the root of the VIBES repo:
 
-    bash bin/setup/install-dependencies.bash
+    bash bin/setup/install-dependencies.bash --wp-branch=codyroux/user-fun-spec-compare
     . bin/common-lib/env.bash
 
 To install these dependencies manually, perform the following steps.
@@ -79,8 +79,12 @@ Then install boolector, e.g.:
     export PATH=$(pwd):$PATH
 
 Clone [cbat_tools](https://github.com/draperlaboratory/cbat_tools), `cd`
-into the `wp/lib/bap_wp` folder, and install with `make`:
+into the `wp` folder, checkout the branch `codyroux/user-fun-spec-compare`, and install with `make`:
 
+    cd ~
+    git clone https://github.com/draperlaboratory/cbat_tools
+    cd cbat_tools/wp
+    git checkout codyroux/user-fun-spec-compare
     make
 
 Install the following opam packages:

--- a/bin/common-lib/slack.bash
+++ b/bin/common-lib/slack.bash
@@ -39,6 +39,8 @@ there_is_a_SLACK_URL () {
 # DESC
 #   Build a slack payload (a JSON file) to send.
 #   The contents are constructed from ${MSG_FILE} and ${REPORT_FILE}.
+# ARGS
+# - ${1}: If "quiet" then only report a summary and errors.
 # RETURNS
 #   The exit code of the attempt to write the file.
 build_slack_payload () {
@@ -46,21 +48,36 @@ build_slack_payload () {
     local BAP
     local BRANCH
     local COMMIT
-    local DATA
+    local FULL_REPORT
+    local JUST_THE_SUMMARY
     local TEXT
+    local VERBOSITY
+    VERBOSITY="${1}"
     MESSAGE="$(cat "${MSG_FILE}")"
     BAP="$(cat "${BAP_VERSION_FILE}")"
+    BRANCH="$(cat "${GIT_BRANCH_FILE}")"
     COMMIT="$(sed -z -e 's/\n/\\n/g' -e 's/\"/\\"/g' "${GIT_COMMIT_FILE}")"
-    DATA="$(sed -z \
+    FULL_REPORT="$(sed -z \
         -e 's/\n/\\n/g' \
         -e 's/\"/\\"/g' \
         -e 's/'\''/\'\''/g' \
         -e 's/'\`'/'\`'/g' \
         "${REPORT_FILE}")"
+    JUST_THE_SUMMARY="$(sed -z \
+        -e 's/\n/\\n/g' \
+        -e 's/\"/\\"/g' \
+        -e 's/'\''/\'\''/g' \
+        -e 's/'\`'/'\`'/g' \
+        "${SUMMARY_FILE}")"
     TEXT="STATUS: ${MESSAGE}"
     TEXT="${TEXT}\nBAP: ${BAP}"
+    TEXT="${TEXT}\nBRANCH: ${BRANCH}"
     TEXT="${TEXT}\nCOMMIT:\n\`\`\`\n${COMMIT}\n\`\`\`"
-    TEXT="${TEXT}\nOUTPUT:\n\`\`\`\n${DATA}\n\`\`\`"
+    if [[ "${VERBOSITY}" == "quiet" ]]; then
+        TEXT="${TEXT}\nOUTPUT:\n\`\`\`\n${JUST_THE_SUMMARY}\n\`\`\`"
+    else 
+        TEXT="${TEXT}\nOUTPUT:\n\`\`\`\n${FULL_REPORT}\n\`\`\`"
+    fi
     echo "{
         \"username\":\"${SLACK_USERNAME}\",
         \"text\":\"${TEXT}\"
@@ -86,9 +103,11 @@ post_to_slack () {
 
 # DESC
 #   Report the current status of things to slack.
+# ARGS
+# - ${1}: If "quiet" then only report a summary and errors.
 # RETURNS
 #   The exit code of the attempt to send the message to slack.
 report_to_slack () {
-    build_slack_payload
+    build_slack_payload "${1}"
     post_to_slack
 }

--- a/bin/common-lib/system-testing.bash
+++ b/bin/common-lib/system-testing.bash
@@ -39,7 +39,7 @@ print_test_startup_info () {
 # DESC
 #   Print a header
 # ARGS
-# - 1 : The message to print
+# - ${1} : The message to print
 print_header () {
     echo "" | tee -a "${REPORT}"
     rule | tee -a "${REPORT}"
@@ -65,13 +65,17 @@ print_summary () {
     echo "|| Passed: ${TESTS_PASSED}," \
 	 "Failed: ${TESTS_FAILED}" | tee -a "${REPORT}"
     rule | tee -a "${REPORT}"
+
+    echo "SYSTEM_TESTS ${TESTS_FINAL_STATUS}" > "${SUMMARY}"
+    echo "${TESTS_TALLY}" >> "${SUMMARY}"
+    echo "Passed: ${TESTS_PASSED}, Failed: ${TESTS_FAILED}" >> "${SUMMARY}"
 }
 
 # DESC
 #     Run an ARM executable with qemu
 # ARGS
-# - 1 : The path to the executable
-# - 2 : The expected exit code
+# - ${1} : The path to the executable
+# - ${2} : The expected exit code
 run_arm_exe () {
     local EXE_PATH="${1}"
     local EXPECTED_EXIT_CODE="${2}"
@@ -117,8 +121,8 @@ run_arm_exe () {
 # DESC
 #     Run a make command
 # ARGS
-# - 1 : The make command
-# - 2 : The expected exit code
+# - ${1} : The make command
+# - ${2} : The expected exit code
 run_make () {
     local CMD="${1}"
     local EXPECTED_EXIT_CODE="${2}"

--- a/bin/common-lib/utils.bash
+++ b/bin/common-lib/utils.bash
@@ -47,20 +47,37 @@ create_tmp_dir () {
 TMP_SCRATCH_DIR="$(create_tmp_dir)"
 MSG_FILE="${TMP_SCRATCH_DIR}/message.txt"
 REPORT_FILE="${TMP_SCRATCH_DIR}/report.txt"
+SUMMARY_FILE="${TMP_SCRATCH_DIR}/summary.txt"
 SLACK_FILE="${TMP_SCRATCH_DIR}/data.json"
 BAP_VERSION_FILE="${TMP_SCRATCH_DIR}/bap-version.txt"
+GIT_BRANCH_FILE="${TMP_SCRATCH_DIR}/git-branch.txt"
 GIT_COMMIT_FILE="${TMP_SCRATCH_DIR}/git-commit.txt"
 echo "Initializing message...no message yet" > "${MSG_FILE}"
 echo "Initializing report...nothing to report yet" > "${REPORT_FILE}"
+echo "Initializing summary...nothing to report yet" > "${SUMMARY_FILE}"
 echo '{"username":"None yet","text":"Nothing yet"}' > "${SLACK_FILE}"
 echo "No BAP version to report yet" > "${BAP_VERSION_FILE}"
-echo "No commit to report yet" > "${GIT_COMMIT_FILE}"
+echo "No git branch to report yet" > "${GIT_BRANCH_FILE}"
+echo "No git commit to report yet" > "${GIT_COMMIT_FILE}"
+
+# DESC
+#     Get filepath to the SUMMARY_FILE.
+# ARGS
+# - ${1} : If "true" then return SUMMARY_FILE.
+#          Otherwise, return /dev/null.
+summary_file () {
+    if [[ "${1}" == "true" ]]; then
+        echo "${SUMMARY_FILE}"
+    else
+        echo "/dev/null"
+    fi
+}
 
 # DESC
 #     Get filepath to the REPORT_FILE.
 # ARGS
-# - 1 : If "true" then return REPORT_FILE.
-#       Otherwise, return /dev/null.
+# - ${1} : If "true" then return REPORT_FILE.
+#          Otherwise, return /dev/null.
 report_file () {
     if [[ "${1}" == "true" ]]; then
         echo "${REPORT_FILE}"
@@ -74,6 +91,13 @@ report_file () {
 bap_version () {
     bap --version > "${BAP_VERSION_FILE}"
     echo "BAP_VERSION: $(cat "${BAP_VERSION_FILE}")"
+}
+
+# DESC
+#   Record the current GIT branch
+git_branch () {
+    git branch | grep "\*" --color=never > "${GIT_BRANCH_FILE}"
+    echo "GIT_BRANCH: $(cat "${GIT_BRANCH_FILE}")"
 }
 
 # DESC

--- a/bin/integration-tests/run-tests.bash
+++ b/bin/integration-tests/run-tests.bash
@@ -76,6 +76,7 @@ REPORT="$(report_file "${REPORT_RESULTS}")"
 
 # Record some useful info.
 bap_version
+git_branch
 git_commit
 
 echo ""
@@ -84,7 +85,7 @@ echo ""
 make clean -C "${REPO_ROOT}"/bap-vibes 2>&1 | tee "${REPORT_FILE}"
 
 # Run the integration tests.
-make test.integration -C "${REPO_ROOT}" 2>&1 | tee -a "${REPORT_FILE}"
+make test.integration -C "${REPO_ROOT}" 2>&1 >> "${REPORT_FILE}"
 TEST_RESULT="${?}"
 echo "REPORT:"
 cat "${REPORT_FILE}"

--- a/bin/setup/install-dependencies.bash
+++ b/bin/setup/install-dependencies.bash
@@ -86,6 +86,7 @@ REPORT="$(report_file "${REPORT_RESULTS}")"
 
 # Record some useful info.
 bap_version
+git_branch
 git_commit
 
 echo ""

--- a/bin/system-tests/run-test.bash
+++ b/bin/system-tests/run-test.bash
@@ -17,6 +17,10 @@ TESTS_DIR="$(cd "${THIS_DIR}/tests" && pwd)"
 
 # Report progress to slack?
 REPORT_RESULTS="false"
+SUMMARY_RESULTS="false"
+
+# Report more than just errors?
+REPORT_VERBOSITY="quiet"
 
 # The name of the test to run.
 TEST_NAME=""
@@ -32,6 +36,7 @@ usage () {
     echo "OPTIONS"
     echo "  -h | --help       Print this help and exit"
     echo "  --report-results  Report the results to slack"
+    echo "  --not-quiet       Report full results, not just a summary"
 }
 
 # Parse the command line arguments.
@@ -45,6 +50,11 @@ while (( "${#}" )); do
 
         --report-results)
             REPORT_RESULTS="true"
+            SUMMARY_RESULTS="true"
+            ;;
+
+        --not-quite)
+            REPORT_VERBOSITY="verbose"
             ;;
 
         *)
@@ -84,9 +94,11 @@ fi
 
 # Where to record progress.
 REPORT="$(report_file "${REPORT_RESULTS}")"
+SUMMARY="$(summary_file "${SUMMARY_RESULTS}")"
 
 # Record some useful info.
 bap_version
+git_branch
 git_commit
 
 # Note that we're starting the tests.
@@ -115,14 +127,14 @@ if [[ "${TESTS_FINAL_STATUS}" == "FAILED" ]]; then
     if [[ "${REPORT_RESULTS}" == "true" ]]; then
         echo "Posting results to slack..."
         echo "System tests failed" > "${MSG_FILE}"
-        report_to_slack
+        report_to_slack "${REPORT_VERBOSITY}"
     fi
     exit 1
 else
     if [[ "${REPORT_RESULTS}" == "true" ]]; then
         echo "Posting results to slack..."
         echo "System tests passed" > "${MSG_FILE}"
-        report_to_slack
+        report_to_slack "${REPORT_VERBOSITY}"
     fi
     exit 0
 fi

--- a/bin/system-tests/run-tests.bash
+++ b/bin/system-tests/run-tests.bash
@@ -17,6 +17,10 @@ TESTS_DIR="$(cd "${THIS_DIR}/tests" && pwd)"
 
 # Report progress to slack?
 REPORT_RESULTS="false"
+SUMMARY_RESULTS="false"
+
+# Report more than just errors?
+REPORT_VERBOSITY="quiet"
 
 # Usage message
 usage () {
@@ -27,6 +31,7 @@ usage () {
     echo "OPTIONS"
     echo "  -h | --help       Print this help and exit"
     echo "  --report-results  Report the results to slack"
+    echo "  --not-quiet       Report full results, not just a summary" 
 }
 
 # Parse the command line arguments.
@@ -40,6 +45,11 @@ while (( "${#}" )); do
 
         --report-results)
             REPORT_RESULTS="true"
+            SUMMARY_RESULTS="true"
+            ;;
+
+        --not-quiet)
+            REPORT_VERBOSITY="verbose"
             ;;
 
         *)
@@ -75,9 +85,11 @@ fi
 
 # Where to record progress.
 REPORT="$(report_file "${REPORT_RESULTS}")"
+SUMMARY="$(summary_file "${SUMMARY_RESULTS}")"
 
 # Record some useful info.
 bap_version
+git_branch
 git_commit
 
 # Note that we're starting the tests.
@@ -97,14 +109,14 @@ if [[ "${TESTS_FINAL_STATUS}" == "FAILED" ]]; then
     if [[ "${REPORT_RESULTS}" == "true" ]]; then
         echo "Posting results to slack..."
         echo "System tests failed" > "${MSG_FILE}"
-        report_to_slack
+        report_to_slack "${REPORT_VERBOSITY}"
     fi
     exit 1
 else
     if [[ "${REPORT_RESULTS}" == "true" ]]; then
         echo "Posting results to slack..."
         echo "System tests passed" > "${MSG_FILE}"
-        report_to_slack
+        report_to_slack "${REPORT_VERBOSITY}"
     fi
     exit 0
 fi

--- a/bin/unit-tests/run-tests.bash
+++ b/bin/unit-tests/run-tests.bash
@@ -76,6 +76,7 @@ REPORT="$(report_file "${REPORT_RESULTS}")"
 
 # Record some useful info.
 bap_version
+git_branch
 git_commit
 
 echo ""
@@ -84,7 +85,7 @@ echo ""
 make clean -C "${REPO_ROOT}"/bap-vibes 2>&1 | tee "${REPORT_FILE}"
 
 # Run the unit tests.
-make test.unit -C "${REPO_ROOT}" 2>&1 | tee -a "${REPORT_FILE}"
+make test.unit -C "${REPO_ROOT}" 2>&1 >> "${REPORT_FILE}"
 TEST_RESULT="${?}"
 echo "REPORT:"
 cat "${REPORT_FILE}"


### PR DESCRIPTION
CHANGES IN THIS PR:

* The system tests print a lot of output, even for successful tests. With this PR, the system tests run in a quieter mode by default. In the quieter mode, the final summary of how many tests passed/failed is printed, but beyond that, only failing tests are printed in full detail. This makes it much quieter, and you really only see verbose output for things that go wrong. There is an option `--not-quiet` option for the system tests if you want to see the full output, even for successful tests.
* With this PR, the tests will now report the current GIT branch (which is detached in the CI, so unimportant for CI, but the GIT branch is useful when running locally).
* With this PR, the tests will correctly report "Unit tests failed" when the tests actually fail. Before this PR, they always said "tests pass" even if they failed.
* I've updated the README.md so that it tells the user how to install `wp` from the correct branch.