### PR TITLE
Fixed failing parse_c unit tests.

### DIFF
--- a/bap-vibes/tests/unit/helpers.ml
+++ b/bap-vibes/tests/unit/helpers.ml
@@ -1,11 +1,8 @@
-open !Core_kernel
+open Core_kernel
 open Bap.Std
-open Bap_knowledge
-open Bap_vibes
 open Bap_core_theory
+open Bap_vibes
 open OUnit2
-
-module KB = Knowledge
 
 (* Skip a test, with a message saying why. *)
 let skip_test (msg : string) : unit = skip_if true msg
@@ -19,7 +16,8 @@ let empty_proj (filename : string) : (Project.t, Error.t) result =
   Project.create input
 
 (* Same as [empty_proj], but fail if loading errors. *)
-let proj_exn (proj : (Project.t * string, Error.t) result) : Project.t * string =
+let proj_exn (proj : (Project.t * string, Error.t) result)
+    : Project.t * string =
   match proj with
   | Ok p -> p
   | Error e ->
@@ -29,13 +27,15 @@ let proj_exn (proj : (Project.t * string, Error.t) result) : Project.t * string 
     end
 
 (* Create a dummy project with an empty main subroutine *)
-let dummy_proj ?name:(name = "main") filename : (Project.t * string, Error.t) result =
+let dummy_proj ?name:(name = "main") filename
+    : (Project.t * string, Error.t) result =
   let empty_proj = empty_proj filename in
   let dummy_main = Sub.create ~name:name () in
   let dummy_prog = Program.Builder.create () in
   Program.Builder.add_sub dummy_prog dummy_main;
   let dummy_prog = Program.Builder.result dummy_prog in
-  Result.map empty_proj ~f:(fun p -> (Project.with_program p dummy_prog, filename))
+  Result.map empty_proj
+    ~f:(fun p -> (Project.with_program p dummy_prog, filename))
 
 (* Create a dummy C function declaration with empty everything *)
 let dummy_code : Cabs.definition =
@@ -46,17 +46,17 @@ let dummy_code : Cabs.definition =
   FUNDEF (single_name, body)
 
 (* Get an empty program that can be used in tests. *)
-let prog_exn (proj : (Project.t * string, Error.t) result) : Program.t * string =
+let prog_exn (proj : (Project.t * string, Error.t) result)
+    : Program.t * string =
   let p, s = proj_exn proj in
   (Project.program p, s)
 
+(* Some dummy values that can be used in tests. *)
 let dummy_target =
   Theory.Target.declare
     ~bits:32
     ~byte:8
     "dummy_tgt"
-
-(* Some dummy values that can be used in tests. *)
 let patch = "ret-3"
 let patch_point_str = "0x3f"
 let patch_point = Bitvec.of_string patch_point_str
@@ -69,8 +69,6 @@ let original_exe = "/path/to/original/exe"
 let patched_exe = "/path/to/patched/exe"
 let minizinc_model_filepath = "/path/to/model.mzn"
 let unit = KB.Object.create Bap_core_theory.Theory.Unit.cls
-let proj = dummy_proj original_exe
-let prog = prog_exn proj
 
 (* A helper to create a [Data] object that can be used in tests. *)
 let obj () = KB.Object.create Data.cls

--- a/bap-vibes/tests/unit/test_parse_c.ml
+++ b/bap-vibes/tests/unit/test_parse_c.ml
@@ -1,104 +1,108 @@
-open Bap_vibes
-open OUnit2
 open Core_kernel
 open Bap_core_theory
-open Bap_knowledge
-open Knowledge.Syntax
-open Knowledge.Let
+open KB.Let
+open Bap_vibes
+open OUnit2
 
 let eff_to_str sem =
   Format.asprintf "%a" (KB.Value.pp_slots ["bap:bil"]) sem |>
   String.filter ~f:(fun c -> not Char.(c = '\"'))
 
-(* Our "golden inputs" compared ignoring whitespace. *)
 let compare_sem sem str =
   let strip s = String.filter s ~f:(Fn.non Char.is_whitespace) in
   String.equal (strip sem) (strip str)
 
 let assert_parse_eq s1 s2 =
   match Parse_c.parse_c_patch s1 with
-    | Error e ->
-      assert_failure
-        (Printf.sprintf "FrontC failed to parse %s\n with error %s" s1 e)
-    | Ok ast ->
-      Bap.Std.Toplevel.exec
-        begin
-          Theory.instance () >>=
-          Theory.require >>= fun (module T) ->
-          let module Eval = Core_c.Eval(T) in
-          let* sem = Eval.c_patch_to_eff Helpers.dummy_target ast in
-          let sem_str = eff_to_str sem in
-          KB.return @@
-          assert_equal ~cmp:compare_sem ~printer:ident sem_str s2
-        end
+  | Error e ->
+    assert_failure
+      (Printf.sprintf "FrontC failed to parse %s\n with error %s" s1 e)
+  | Ok ast ->
+    Bap.Std.Toplevel.exec
+      begin
+        let* theory = Theory.instance () in
+        let* (module T) = Theory.require theory in
+        let module Eval = Core_c.Eval(T) in
+        let* sem = Eval.c_patch_to_eff Helpers.dummy_target ast in
+        let sem_str = eff_to_str sem in
+        KB.return @@ assert_equal ~cmp:compare_sem ~printer:ident s2 sem_str
+      end
 
+let test_var_decl _ =
+  assert_parse_eq
+    "int x, y, z;"
+    "(())"
 
-let test_var_decl _ = assert_parse_eq "int x, y, z;" "(())"
+let test_assign _ =
+  assert_parse_eq
+    "int x, y; x = y;"
+    "{ x := y }"
 
-let test_assign _ = assert_parse_eq "int x, y; x = y;" "{ x := y }"
-
-let test_seq _ = assert_parse_eq "int x, y, z; x = y; y = z;" "{ x := y y := z }"
+let test_seq _ =
+  assert_parse_eq
+    "int x, y, z; x = y; y = z;"
+    "{ x := y y := z }"
 
 let test_ite _ =
   assert_parse_eq
     "int cond_expr; if(cond_expr){goto l1;}else{goto l2;};"
     "{
-     if (cond_expr) {
-      bap:call(l1)
-     } else {
-       bap:call(l2)
-      }
+       if (cond_expr) {
+         call(l1)
+       } else {
+         call(l2)
+       }
      }"
 
 let test_fallthrough _ =
   assert_parse_eq
     "int x, y, z; if (x) { goto l; } x = z; "
     "{
-   if (x) {
-     bap:call(l)
-   }
-   x := z
-   }"
+       if (x) { call(l) }
+       x := z
+     }"
 
 let test_array _ =
   assert_parse_eq
     "int a, y; y = a[7];"
     "{ y := mem[a + 7, el]:u32 }"
 
-let test_compound _ = assert_parse_eq
-  "int x, y, z;
-   char q;
-   x = 0x7;
-   x = *y;
-   if((signed int)x > (signed int)0){
+let test_compound _ =
+  assert_parse_eq
+    "int x, y, z;
+     char q;
+     x = 0x7;
+     x = *y;
+     if((signed int)x > (signed int)0){
        goto fred;
-   } else {
+     } else {
        goto larry;
-   }"
-  "{
-   x := 7
-   x := mem[y, el]:u32
-   if (0 <$ x) {
-      bap:call(fred)
-    } else {
-      bap:call(larry)
-     }
-    }"
+     }"
+    "{
+       x := 7
+       x := mem[y, el]:u32
+       if (0 <$ x) {
+         call(fred)
+       } else {
+         call(larry)
+       }
+     }"
 
-let test_call_hex _ = assert_parse_eq
-  "int temp;
-   if (temp == 0)
-    { (0x3ec)(); }"
-  "{
-   if (temp = 0) {
-     jmp 0x3EC
-   }
- }"
+let test_call_hex _ =
+  assert_parse_eq
+    "int temp;
+     if (temp == 0) { (0x3ec)(); }"
+    "{
+       if (temp = 0) {
+         jmp 0x3EC
+       }
+     }"
 
-let test_load_short _ = assert_parse_eq
-  "int x, y;
-   x = * (short *) y;"
-  "{ x := mem[y, el]:u16 }"
+let test_load_short _ =
+  assert_parse_eq
+    "int x, y;
+     x = * (short *) y;"
+    "{ x := mem[y, el]:u16 }"
 
 let suite = [
   "Test vardecls" >:: test_var_decl;

--- a/bap-vibes/tests/unit/test_verifier.ml
+++ b/bap-vibes/tests/unit/test_verifier.ml
@@ -5,17 +5,12 @@ module Wp_params = Bap_wp.Run_parameters
 module H = Helpers
 
 (* Some dummy values to use in the tests below. *)
-let orig_proj = H.dummy_proj "orig_exe" ~name:H.func
-let orig_prog = H.prog_exn orig_proj
-let patch_proj = H.dummy_proj "patched_exe" ~name:H.func
-let patch_prog = H.prog_exn patch_proj
 let tgt = Bap_core_theory.Theory.Target.unknown
 let params =
   {
     (Wp_params.default ~func:H.func) with
     postcond = (Core_kernel.Sexp.to_string H.property)
   }
-
 
 (* A helper to print the results. *)
 let res_str r : string =
@@ -28,6 +23,10 @@ let res_str r : string =
 
 (* Test that the verifier works as expected when [WP] returns [UNSAT]. *)
 let test_verify_unsat (_ : test_ctxt) : unit =
+  let orig_proj = H.dummy_proj "orig_exe" ~name:H.func in
+  let orig_prog = H.prog_exn orig_proj in
+  let patch_proj = H.dummy_proj "patched_exe" ~name:H.func in
+  let patch_prog = H.prog_exn patch_proj in
   let result = Verifier.verify tgt params
     ~orig_prog ~patch_prog
     ~verifier:H.verify_unsat
@@ -40,6 +39,10 @@ let test_verify_unsat (_ : test_ctxt) : unit =
 
 (* Test that the verifier works as expected when [WP] returns [SAT]. *)
 let test_verify_sat (_ : test_ctxt) : unit =
+  let orig_proj = H.dummy_proj "orig_exe" ~name:H.func in
+  let orig_prog = H.prog_exn orig_proj in
+  let patch_proj = H.dummy_proj "patched_exe" ~name:H.func in
+  let patch_prog = H.prog_exn patch_proj in
   let result = Verifier.verify tgt params
     ~orig_prog ~patch_prog
     ~verifier:H.verify_sat
@@ -52,6 +55,10 @@ let test_verify_sat (_ : test_ctxt) : unit =
 
 (* Test that the verifier works as expected when [WP] returns [UNKNOWN]. *)
 let test_verify_unknown (_ : test_ctxt) : unit =
+  let orig_proj = H.dummy_proj "orig_exe" ~name:H.func in
+  let orig_prog = H.prog_exn orig_proj in
+  let patch_proj = H.dummy_proj "patched_exe" ~name:H.func in
+  let patch_prog = H.prog_exn patch_proj in
   let result = Verifier.verify tgt params
     ~orig_prog ~patch_prog
     ~verifier:H.verify_unknown


### PR DESCRIPTION
Tests passing now (so fixing #119). The trick is to ensure that `Project.create` is not called before `Bap_main.init ()`. 

Apart from a few stylistic changes, the important changes I made to ensure that the `parse_c` unit tests pass are these:
* Do not create a project at the top level of the `bap-vibes/tests/unit/helpers.ml` module.
* Do not create `orig_proj` and `patch_proj` at the top level of the `bap-vibes/tests/unit/test_verifier.ml` unit tests. Instead, create those projects inside each unit test that needs them.
