### PR TITLE
Removed block merging from fallthrough jump fusion

### DIFF
--- a/bap-vibes/src/bir_passes.mli
+++ b/bap-vibes/src/bir_passes.mli
@@ -30,10 +30,10 @@ module Opt : sig
       to put the patch code in good shape before instruction selection. *)
   val apply : blk term list -> blk term list
 
-  (** [merge_adjacent ir] attempts to merge adjacent blocks in [ir] with an
+  (** [remove_fallthrough_jmp ir] attempts to merge adjacent blocks in [ir] with an
       edge in between them. Requires the blocks to be ordered according to a
       reverse post-order DFS traversal. *)
-  val merge_adjacent : blk term list -> blk term list
+  val remove_fallthrough_jmp : blk term list -> blk term list
   
 end
 

--- a/bap-vibes/tests/unit/test_bir_opt.ml
+++ b/bap-vibes/tests/unit/test_bir_opt.ml
@@ -85,9 +85,9 @@ let test_failure_mov _ =
     end
   | _ -> assert_failure "Unexpected block shape!"
 
-let test_merge _ =
+let test_remove_fallthrough _ =
   let blks = [blk_dir; blk_uncond_dir; blk_redir] in
-  let opts = Bir_passes.Opt.merge_adjacent blks in
+  let opts = Bir_passes.Opt.remove_fallthrough_jmp blks in
   match opts with
   | [blk1; blk2] ->
     let tid1 = Term.tid blk1 in
@@ -136,5 +136,5 @@ let suite = [
   "Test success" >:: test_success;
   "Test failure branch" >:: test_failure_branch;
   "Test failure mov" >:: test_failure_mov;
-  "Test merge" >:: test_merge;
+  "Test remove fallthrough" >:: test_remove_fallthrough;
 ]


### PR DESCRIPTION
Merging of blocks was causing other jumps to become dangling to non existent tids. I don't see a problem with removing fallthrough jmps but not merging the two blocks.