### PR TITLE
Refactor ins_outs map to run over old instruction selector

### DIFF
--- a/bap-vibes/src/arm_selector.ml
+++ b/bap-vibes/src/arm_selector.ml
@@ -711,7 +711,7 @@ end
 let ir_of_arm_eff (t : arm_eff) : Ir.t KB.t =
   if not (List.is_empty t.current_data && List.is_empty t.current_ctrl)
   then Err.(fail @@ Other "Arm_selector.ir: expected empty data and ctrl")
-  else KB.return @@ Ir.add_in_vars t.other_blks
+  else KB.return t.other_blks
 
 
 module ARM_Gen =

--- a/bap-vibes/src/compiler.ml
+++ b/bap-vibes/src/compiler.ml
@@ -50,9 +50,9 @@ let create_vibes_ir
   let* lang = Data.Patch.get_lang patch in
   let* tgt = Data.Patch.get_target patch in
   let* is_arm = Arm.is_arm lang and* is_thumb = Arm.is_thumb lang in
-  let* ir =
+  let+ ir =
     if is_arm || is_thumb then
-      let+ ir = 
+      let* ir = 
         match isel_model_filepath with
         | None ->
           Arm.ARM_Gen.select ir
@@ -65,11 +65,11 @@ let create_vibes_ir
                   sprintf "The patch has the following BIL: %a" Blk.pps blk)));
           let+ ir = Isel.run ~isel_model_filepath ir Arm.Isel.patterns in
           ir in
+      let+ ins_outs_map = Data.Patch.get_ins_outs_map patch in
+      let ir = Isel.populate_ins_outs ins_outs_map ir in
       Arm.preassign tgt ir ~is_thumb
     else Kb_error.(fail @@ Other (
         sprintf "Unsupported lang %s" (Theory.Language.to_string lang))) in
-  let+ ins_outs_map = Data.Patch.get_ins_outs_map patch in
-  let ir = Isel.populate_ins_outs ins_outs_map ir in
   ir, exclude_regs
 
 (* Compile one patch from BIR to VIBES IR *)

--- a/bap-vibes/src/ir.mli
+++ b/bap-vibes/src/ir.mli
@@ -198,12 +198,6 @@ val freshen_operands : t -> t
 (** [freshen_operation_ids] gives a unique tid to every operation *)
 val freshen_operation_ids : t -> t
 
-(** [add_in_vars t] initializes the [in] field of every block. It
-    operates by collecting all the variables appearing on rhs that are
-    not defined by an lhs before-hand, and adding the new ones to the
-    [in] field of the current block. *)
-val add_in_vars : t -> t
-
 (** Various getter functions *)
 val operation_opcodes : t -> opcode list Int.Map.t
 val all_opcodes : t -> opcode list

--- a/bap-vibes/src/isel.ml
+++ b/bap-vibes/src/isel.ml
@@ -680,8 +680,14 @@ let populate_ins_outs (ins_outs_map : Data.ins_outs Tid.Map.t) (vir : Ir.t) : Ir
     | Some {ins ; outs} ->
       let operands vars =
         let vars = Var.Set.to_list vars in
-        (* TODO: Assuming Ir.Var is not right here. They may Void. *)
-        let vars = List.map ~f:(fun v -> Ir.Var (Ir.simple_var v)) vars in
+        (* TODO: This is not a good way to find register class *)
+        let vars = List.map vars ~f:(fun v ->
+          let sv = Ir.simple_var v in
+          match (Var.typ v) with
+          | Imm _     -> Ir.Var sv
+          | Mem (_,_) -> Ir.Void sv
+          | Unk       -> Ir.Void sv)
+        in
         vars
       in
       let in_operands = operands ins in

--- a/bap-vibes/src/isel.ml
+++ b/bap-vibes/src/isel.ml
@@ -665,36 +665,39 @@ module Merge = struct
       congruent = List.append vir1.congruent vir2.congruent
     }
   let merge
-    (ins_outs_map : Data.ins_outs Tid.Map.t)
     (good_templates : Ir.t list) : Ir.t =
     let vir = List.reduce ~f:merge_ir good_templates in
     let vir = Option.value ~default:Ir.empty vir in
-    let vir = Ir.map_blks vir ~f:(fun blk ->
-      match Tid.Map.find ins_outs_map blk.id with
-      | None -> blk
-      | Some {ins ; outs} ->
-        let operands vars =
-          let vars = Var.Set.to_list vars in
-          (* TODO: Assuming Ir.Var is not right here. They may Void. *)
-          let vars = List.map ~f:(fun v -> Ir.Var (Ir.simple_var v)) vars in
-          vars
-        in
-        let in_operands = operands ins in
-        let ins = Ir.empty_op () in
-        let ins = {ins with lhs = blk.ins.lhs @ in_operands} in
-        let out_operands = operands outs in
-        let outs = Ir.empty_op () in
-        let outs = {outs with operands = blk.outs.operands @ out_operands} in
-        {blk with ins; outs}
-      )
-    in
     vir
+
 
 end
 
+let populate_ins_outs (ins_outs_map : Data.ins_outs Tid.Map.t) (vir : Ir.t) : Ir.t =
+  let vir = Ir.map_blks vir ~f:(fun blk ->
+    match Tid.Map.find ins_outs_map blk.id with
+    | None -> blk
+    | Some {ins ; outs} ->
+      let operands vars =
+        let vars = Var.Set.to_list vars in
+        (* TODO: Assuming Ir.Var is not right here. They may Void. *)
+        let vars = List.map ~f:(fun v -> Ir.Var (Ir.simple_var v)) vars in
+        vars
+      in
+      let in_operands = operands ins in
+      let ins = Ir.empty_op () in
+      let ins = {ins with lhs = blk.ins.lhs @ in_operands} in
+      let out_operands = operands outs in
+      let outs = Ir.empty_op () in
+      let outs = {outs with operands = blk.outs.operands @ out_operands} in
+      {blk with ins; outs}
+    )
+  in
+  vir
+
+
 let run
     ~isel_model_filepath:(isel_model_filepath : string)
-    (ins_outs_map : Data.ins_outs Tid.Map.t)
     (matchee : Blk.t list)
     (pats : (Pattern.t * Template.t) String.Map.t) : Ir.t Knowledge.t =
   Events.(send @@ Info "Running Instruction Selector.\n");
@@ -723,5 +726,5 @@ let run
     | Ok sol_serial -> KB.return sol_serial
     | Error msg -> Kb_error.fail (Kb_error.Minizinc_deserialization msg) in
   let good_templates = Pattern.Serial.filter_templates sol_serial templates in
-  let vir = Merge.merge ins_outs_map good_templates in
+  let vir = Merge.merge good_templates in
   KB.return vir

--- a/bap-vibes/src/isel.mli
+++ b/bap-vibes/src/isel.mli
@@ -91,6 +91,9 @@ module Utils : sig
   val z : Var.t
 end
 
+(** [populate_ins_outs] uses the ins_outs_map to populate the
+    ins and outs operations with operands
+*)
 val populate_ins_outs : Data.ins_outs Tid.Map.t -> Ir.t -> Ir.t
 
 val run :

--- a/bap-vibes/src/isel.mli
+++ b/bap-vibes/src/isel.mli
@@ -91,9 +91,10 @@ module Utils : sig
   val z : Var.t
 end
 
+val populate_ins_outs : Data.ins_outs Tid.Map.t -> Ir.t -> Ir.t
+
 val run :
   isel_model_filepath:string ->
-  Data.ins_outs Tid.Map.t ->
   Blk.t list ->
   info ->
   Ir.t KB.t


### PR DESCRIPTION
There was a state in which the new variables discovered were added to congruences, but not added to the ins outs fields on the old instruction selector path. This was leading to an inconsistent state on minizinc solve