### PR TITLE
Remove use of `addw` from the selector

### DIFF
--- a/bap-vibes/src/arm_selector.ml
+++ b/bap-vibes/src/arm_selector.ml
@@ -303,7 +303,6 @@ module ARM_ops = struct
     let mov set_flags = op (if set_flags then "movs" else "mov")
     let movw = op "movw"
     let add set_flags = op (if set_flags then "adds" else "add")
-    let addw = op "addw"
     let mul = op "mul"
     let sub set_flags = op (if set_flags then "subs" else "sub")
     let neg = op "neg"
@@ -480,18 +479,7 @@ module ARM_ops = struct
 
   let add (arg1 : arm_pure) (arg2 : arm_pure)
       ~(is_thumb : bool) : arm_pure KB.t =
-    let {op_val; _} = arg2 in
-    let fits_in_3 w =
-      let open Word in
-      let width = bitwidth w in
-      of_int ~width 0 <= w && w <= of_int ~width 7
-    in
-    match op_val with
-    | Const w when not (fits_in_3 w) && Word.to_int_exn w <= 0xFFF ->
-      (* addw can accept up to 12 bits for the immediate. *)
-      KB.return @@ binop Ops.addw word_ty arg1 arg2 ~is_thumb
-    | _ ->
-      KB.return @@ binop Ops.(add is_thumb) word_ty arg1 arg2 ~is_thumb
+    KB.return @@ binop Ops.(add is_thumb) word_ty arg1 arg2 ~is_thumb
 
   let neg (arg : arm_pure) ~(is_thumb : bool) : arm_pure KB.t =
     KB.return @@ uop Ops.neg word_ty arg ~is_thumb

--- a/bap-vibes/tests/unit/test_arm_selector.ml
+++ b/bap-vibes/tests/unit/test_arm_selector.ml
@@ -369,7 +369,7 @@ let test_ir14 ctxt =
   test_ir ctxt Prog14.prog [blk_pat ^ ":"; "bl some_function"]
 
 let test_ir15 ctxt =
-  test_ir ctxt Prog15.prog [blk_pat ^ ":"; "addw R0, R0, #42"]
+  test_ir ctxt Prog15.prog [blk_pat ^ ":"; "add R0, R0, #42"]
 
 let test_ir16 ctxt =
   test_ir ctxt Prog16.prog [blk_pat ^ ":"; "mov R0, R0"]


### PR DESCRIPTION
It turns out that with `.syntax unified` the assembler can figure out whether to use the wide or narrow encoding in Thumb mode.