### PR TITLE
Fixes bitrot (partially)

### DIFF
--- a/bap-vibes/src/bir_passes.ml
+++ b/bap-vibes/src/bir_passes.ml
@@ -807,7 +807,7 @@ let to_linear_ssa
   sub |> Sub.ssa |> Linear_ssa.transform ~patch:(Some patch)
 
 let run (patch : Data.Patch.t) : t KB.t =
-  let* code = Data.Patch.get_bir patch in
+  let* code = Data.Patch.get_sem patch in
   let info_str = Format.asprintf "\nPatch: %a\n\n%!" KB.Value.pp code in
   Events.(send @@ Info info_str);
   let* tgt = Data.Patch.get_target patch in

--- a/bap-vibes/src/data.mli
+++ b/bap-vibes/src/data.mli
@@ -134,7 +134,7 @@ module Patch : sig
 
   (* This initializes the semantics slot by creating a program label
      that will contain the semantics. This *must* be called before
-     set_bir! *)
+     set_sem! *)
   val init_sem : t -> unit KB.t
   val set_sem : t -> insn -> unit KB.t
   val get_sem : t -> insn KB.t

--- a/bap-vibes/src/data.mli
+++ b/bap-vibes/src/data.mli
@@ -136,8 +136,8 @@ module Patch : sig
      that will contain the semantics. This *must* be called before
      set_bir! *)
   val init_sem : t -> unit KB.t
-  val set_bir : t -> insn -> unit KB.t
-  val get_bir : t -> insn KB.t
+  val set_sem : t -> insn -> unit KB.t
+  val get_sem : t -> insn KB.t
 
   val set_raw_ir : t -> (Ir.t * Graphs.Tid.t) option -> unit KB.t
   val get_raw_ir : t -> (Ir.t * Graphs.Tid.t) option KB.t

--- a/bap-vibes/src/kb_error.ml
+++ b/bap-vibes/src/kb_error.ml
@@ -38,6 +38,7 @@ type t =
   | Missing_func
   | Missing_property
   | Missing_raw_ir
+  | Missing_label_for_semantics
   | Missing_semantics of string
   | Command_not_found of string
   | Patch_code_not_parsed of string
@@ -81,6 +82,8 @@ let pp ppf (e : t) =
     | Missing_func -> "No function name to verify was stashed in KB"
     | Missing_property -> "No correctness property was stashed in KB"
     | Missing_raw_ir -> "Raw Ir compiled from core_theory not found in KB"
+    | Missing_label_for_semantics ->
+      "No label for patch semantics was stashed in KB"
     | Missing_semantics s -> Format.sprintf "Semantics for %s not found in KB" s
     | Command_not_found s -> s
     | Patch_code_not_parsed s -> "Failed to parse patch code: " ^ s

--- a/bap-vibes/src/kb_error.mli
+++ b/bap-vibes/src/kb_error.mli
@@ -40,6 +40,7 @@ type t =
   | Missing_func
   | Missing_property
   | Missing_raw_ir
+  | Missing_label_for_semantics
   | Missing_semantics of string
   | Command_not_found of string
   | Patch_code_not_parsed of string

--- a/bap-vibes/src/patch_ingester.ml
+++ b/bap-vibes/src/patch_ingester.ml
@@ -22,8 +22,7 @@ module KB = Knowledge
 open KB.Let
 
 let provide_bir (tgt : Theory.target) (patch : Data.Patch.t) : unit KB.t =
-  Theory.instance () >>=
-  Theory.require >>= fun (module Core) ->
+  Theory.instance () >>= Theory.require >>= fun (module Core) ->
   let module CParser = Core_c.Eval(Core) in
   Data.Patch.init_sem patch >>= fun () ->
   Data.Patch.get_patch_name_exn patch >>= fun name ->
@@ -32,16 +31,16 @@ let provide_bir (tgt : Theory.target) (patch : Data.Patch.t) : unit KB.t =
   let code_str = Utils.print_c Cprint.print_def code in
   Events.(send @@ Info (Printf.sprintf "%s" code_str));
 
-  (* Get the patch (as BIR). *)
+  (* Get the patch (as a Theory.Semantics snapshot). *)
   let* hvars = Data.Patch.get_patch_vars_exn patch in
-  let* bir = CParser.c_patch_to_eff hvars tgt code in
+  let* sem = CParser.c_patch_to_eff hvars tgt code in
 
   Events.(send @@ Info "The patch has the following BIL:");
   Events.(send @@ Rule);
-  let bir_str = Format.asprintf "%a" Bil.pp (KB.Value.get Bil.slot bir) in
-  Events.(send @@ Info bir_str);
+  let bil_str = Format.asprintf "%a" Bil.pp (KB.Value.get Bil.slot sem) in
+  Events.(send @@ Info bil_str);
   Events.(send @@ Rule);
-  Data.Patch.set_bir patch bir
+  Data.Patch.set_sem patch sem
 
 (* Ingests a single patch, populating the relevant fields of the KB,
    most notably the semantics field of the corresponding patch (and
@@ -50,11 +49,10 @@ let ingest_one (tgt : Theory.target) (patch_num : int KB.t) (patch : Data.Patch.
     : int KB.t =
   patch_num >>= fun patch_num ->
   Events.(send @@ Info (Printf.sprintf "\nIngesting patch %d." patch_num));
-  (Data.Patch.get_assembly patch >>= fun asm ->
-  match asm with
-  | Some _asm -> KB.return () (* Assembly is user provided *)
-  | None -> provide_bir tgt patch) >>= fun () ->
-  KB.return @@ patch_num+1
+  begin Data.Patch.get_assembly patch >>= function
+    | Some _ -> KB.return () (* Assembly is user provided *)
+    | None -> provide_bir tgt patch
+  end >>= fun () -> KB.return (patch_num + 1)
 
 (* Processes the whole patch associated with [obj], populating all the
    relevant KB slots with semantic data associated with the patch
@@ -65,8 +63,9 @@ let ingest (obj : Data.t) : unit KB.t =
   Events.(send @@ Info "Retreiving data from KB...");
   Data.Original_exe.get_target_exn obj >>= fun tgt ->
   Data.Patched_exe.get_patches obj >>= fun patches ->
-  Events.(send @@ Info (Printf.sprintf "There are %d patches"
-                          (Data.Patch_set.length patches)));
+  Events.send @@ Info (
+    Printf.sprintf "There are %d patches" @@
+    Data.Patch_set.length patches);
 
   Data.Patch_set.fold patches
     ~init:(KB.return 1)

--- a/bap-vibes/src/patch_ingester.ml
+++ b/bap-vibes/src/patch_ingester.ml
@@ -21,7 +21,7 @@ open Bap_core_theory
 module KB = Knowledge
 open KB.Let
 
-let provide_bir (tgt : Theory.target) (patch : Data.Patch.t) : unit KB.t =
+let provide_sem (tgt : Theory.target) (patch : Data.Patch.t) : unit KB.t =
   Theory.instance () >>= Theory.require >>= fun (module Core) ->
   let module CParser = Core_c.Eval(Core) in
   Data.Patch.init_sem patch >>= fun () ->
@@ -51,7 +51,7 @@ let ingest_one (tgt : Theory.target) (patch_num : int KB.t) (patch : Data.Patch.
   Events.(send @@ Info (Printf.sprintf "\nIngesting patch %d." patch_num));
   begin Data.Patch.get_assembly patch >>= function
     | Some _ -> KB.return () (* Assembly is user provided *)
-    | None -> provide_bir tgt patch
+    | None -> provide_sem tgt patch
   end >>= fun () -> KB.return (patch_num + 1)
 
 (* Processes the whole patch associated with [obj], populating all the

--- a/bap-vibes/src/pipeline.ml
+++ b/bap-vibes/src/pipeline.ml
@@ -127,6 +127,8 @@ let rec cegis ?count:(count=1) ?max_tries:(max_tries=None)
   let+ value, new_state = run_KB_computation computation state in
 
   let+ tmp_patched_filepath = get_tmp_patched_exe_filepath value in
+  Events.send @@ Info (
+    Printf.sprintf "Temp patched exe: %s" tmp_patched_filepath);
 
   (* Temporarily use the new KB state when loading the patched binary. *)
   Toplevel.set new_state;

--- a/bap-vibes/src/seeder.ml
+++ b/bap-vibes/src/seeder.ml
@@ -72,6 +72,7 @@ let extract_seed (value : Data.computed) (s : KB.state)
 (* Create a patch set. *)
 let create_patches
     ?seed:(seed=None)
+    (proj : project)
     (ps : Config.patch list)
     : Data.Patch_set.t KB.t =
   let create_patch (seed : t option) (p : Config.patch) : Data.Patch.t KB.t =
@@ -81,10 +82,7 @@ let create_patches
       Utils.get_lang
         ~addr:(Config.patch_point p)
     in
-    let* tgt =
-      Utils.get_target
-        ~addr:(Config.patch_point p)
-    in
+    let tgt = Project.target proj in
     let* () = Data.Patch.set_patch_name obj (Some patch_name) in
     let* () = match Config.patch_code p with
       | CCode ccode -> Data.Patch.set_patch_code obj (Some ccode)
@@ -143,7 +141,7 @@ let init_KB
   let mzn_model_filepath = Config.minizinc_model_filepath config in
   let target = Bap.Std.Project.target proj in
   let addr_size = Theory.Target.bits target in
-  let* patches = create_patches patch_list ~seed in
+  let* patches = create_patches proj patch_list ~seed in
   let* patch_spaces = create_patch_spaces patch_spaces in
   let* obj = KB.Object.create Data.cls in
   let* () = Data.Original_exe.set_filepath obj (Some filename) in

--- a/bap-vibes/tests/integration/patches.ml
+++ b/bap-vibes/tests/integration/patches.ml
@@ -26,16 +26,14 @@ module Ret_3 = struct
   open Theory
 
   let prog (bits : int) : unit eff =
-    Theory.instance
-      ~context:["vibes"]
-      ~requires:["bil"; "vibes:arm-gen"] () >>=
-    Theory.require >>=
-    fun (module Core) ->
+    Theory.instance () >>= Theory.require >>= fun (module Core) ->
     let open Core in
     let open Bap_vibes.Core_notations.Make(Core) in
 
     let word_t = Bitv.define bits in
-    let r0 = Var.define word_t "R0" in
+    let r0 =
+      Var.define word_t @@
+      Bap_vibes.Substituter.Naming.mark_reg_name "R0" in
     let three = int word_t Bitvec.M32.(!!3) in
     let data = data_body
         [
@@ -49,15 +47,14 @@ module Ret_3 = struct
 end
 
 (* The names of the patches. *)
-let patches =
+let patches : (int -> insn KB.t) String.Map.t =
   Map.of_alist_exn (module String) [ "ret-3", Ret_3.prog; ]
 
 (* Helpers. *)
-let names = Map.keys patches
-
+let names : string list = Map.keys patches
 let is_patch (name : string) : bool = List.mem names name ~equal:String.equal
 
-(* [get_bir "ret-3" 32] returns the [Ret_3.bil] BIL, with 32-bit words. *)
-let get_bir (name : string) (bits : int) : Insn.t KB.t =
+(* [get_sem "ret-3" 32] returns the [Ret_3.bil] BIL, with 32-bit words. *)
+let get_sem (name : string) (bits : int) : insn KB.t =
   let patch = Map.find_exn patches name in
   patch bits

--- a/bap-vibes/tests/integration/test_minizinc.ml
+++ b/bap-vibes/tests/integration/test_minizinc.ml
@@ -121,7 +121,7 @@ let test_minizinc_ex1 (ctxt : test_ctxt) : unit =
     KB.Object.create Data.cls >>= fun obj ->
     KB.Object.create Data.Patch.patch >>= fun patch ->
     Data.Patch.init_sem patch >>= fun () ->
-    Patches.get_bir "ret-3" 32 >>= fun bil ->
+    Patches.get_sem "ret-3" 32 >>= fun bil ->
     Data.Patch.set_sem patch bil >>= fun () ->
     Data.Patched_exe.set_patches obj
       (Data.Patch_set.singleton patch) >>= fun () ->

--- a/bap-vibes/tests/integration/test_minizinc.ml
+++ b/bap-vibes/tests/integration/test_minizinc.ml
@@ -122,7 +122,7 @@ let test_minizinc_ex1 (ctxt : test_ctxt) : unit =
     KB.Object.create Data.Patch.patch >>= fun patch ->
     Data.Patch.init_sem patch >>= fun () ->
     Patches.get_bir "ret-3" 32 >>= fun bil ->
-    Data.Patch.set_bir patch bil >>= fun () ->
+    Data.Patch.set_sem patch bil >>= fun () ->
     Data.Patched_exe.set_patches obj
       (Data.Patch_set.singleton patch) >>= fun () ->
     Arm_selector.gpr arm_tgt arm_lang >>= fun gpr ->

--- a/bap-vibes/tests/unit/patches.ml
+++ b/bap-vibes/tests/unit/patches.ml
@@ -26,16 +26,14 @@ module Ret_3 = struct
   open Theory
 
   let prog (bits : int) : unit eff =
-    Theory.instance
-      ~context:["vibes"]
-      ~requires:["bil"; "vibes:arm-gen"] () >>=
-    Theory.require >>=
-    fun (module Core) ->
+    Theory.instance () >>= Theory.require >>= fun (module Core) ->
     let open Core in
     let open Bap_vibes.Core_notations.Make(Core) in
 
     let word_t = Bitv.define bits in
-    let r0 = Var.define word_t "R0" in
+    let r0 =
+      Var.define word_t @@
+      Bap_vibes.Substituter.Naming.mark_reg_name "R0" in
     let three = int word_t Bitvec.M32.(!!3) in
     let data = data_body
         [
@@ -57,7 +55,7 @@ let names = Map.keys patches
 
 let is_patch (name : string) : bool = List.mem names name ~equal:String.equal
 
-(* [get_bir "ret-3" 32] returns the [Ret_3.bil] BIL, with 32-bit words. *)
-let get_bir (name : string) (bits : int) : Insn.t KB.t =
+(* [get_sem "ret-3" 32] returns the [Ret_3.bil] BIL, with 32-bit words. *)
+let get_sem (name : string) (bits : int) : Insn.t KB.t =
   let patch = Map.find_exn patches name in
   patch bits

--- a/bap-vibes/tests/unit/test_compiler.ml
+++ b/bap-vibes/tests/unit/test_compiler.ml
@@ -32,10 +32,6 @@ let dummy_solver
 
 (* Test that [Compiler.compile] works as expected. *)
 let test_compile (_ : test_ctxt) : unit =
-
-  (* Skip this test for now. *)
-  (* H.skip_test "Doesn't work without the dummy solver"; *)
-
   (* Run the compiler. *)
   let computation =
     (* Set up the KB. *)

--- a/bap-vibes/tests/unit/test_patch_ingester.ml
+++ b/bap-vibes/tests/unit/test_patch_ingester.ml
@@ -39,11 +39,11 @@ let test_ingest (_ : test_ctxt) : unit =
     match Data.Patch_set.to_list patches with
     | [] -> assert_failure "Result patch missing."
     | (p :: []) ->
-      Data.Patch.get_bir p >>= fun bir ->
+      Data.Patch.get_sem p >>= fun sem ->
       Patches.Ret_3.prog 32 >>= fun expected ->
       let open Bap.Std in
       let expected = KB.Value.get Bil.slot expected in
-      let bil = KB.Value.get Bil.slot bir in
+      let bil = KB.Value.get Bil.slot sem in
       let err =
         Format.asprintf "Expected %a but got %a"
           Bil.pp expected

--- a/resources/exes/thumb-no-verification/config.json
+++ b/resources/exes/thumb-no-verification/config.json
@@ -1,6 +1,7 @@
 {
   "max-tries": 3,
   "perform-verification" : false,
+  "ogre": "loader.ogre",
   "patches" : [
     {"patch-name" : "ret-3",
      "patch-code" : "int retvar; retvar = 3;",

--- a/resources/exes/thumb-no-verification/loader.ogre
+++ b/resources/exes/thumb-no-verification/loader.ogre
@@ -1,0 +1,30 @@
+(declare arch (name str))
+(declare bits (size int))
+(declare base-address (addr int))
+(declare entry-point (addr int))
+(declare is-little-endian (flag bool))
+(declare mapped (addr int) (size int) (off int))
+(declare code-region (addr int) (size int) (off int))
+(declare named-region (addr int) (size int) (name str))
+(declare segment (addr int) (size int) (r bool) (w bool) (x bool))
+(declare section (addr int) (size int))
+(declare code-start (addr int))
+(declare named-symbol (addr int) (name str))
+(declare symbol-chunk (addr int) (size int) (root int))
+
+(arch thumb)
+(bits 32)
+(is-little-endian true)
+
+(base-address (addr 0x10000))
+(entry-point (addr 0x102d8))
+
+(mapped (addr 0x103c8) (size 0xc) (off 0x3c8))
+
+(named-region (addr 0x103c8) (size 0xc) (name main))
+
+(code-start (addr 0x103c8))
+(named-symbol (addr 0x103c8) (name main))
+
+(code-region (addr 0x103c8) (size 0xc) (off 0x3c8))
+(symbol-chunk (addr 0x103c8) (size 0xc) (root 0x103c8))

--- a/resources/exes/thumb-patch-space/config.json
+++ b/resources/exes/thumb-patch-space/config.json
@@ -4,6 +4,7 @@
     "func": "main",
     "postcond" : "(assert true)"
   },
+  "ogre": "loader.ogre",
   "patch-space" : [
     {"offset" : "0x3c8",
      "size" : "24"}

--- a/resources/exes/thumb-patch-space/loader.ogre
+++ b/resources/exes/thumb-patch-space/loader.ogre
@@ -1,0 +1,30 @@
+(declare arch (name str))
+(declare bits (size int))
+(declare base-address (addr int))
+(declare entry-point (addr int))
+(declare is-little-endian (flag bool))
+(declare mapped (addr int) (size int) (off int))
+(declare code-region (addr int) (size int) (off int))
+(declare named-region (addr int) (size int) (name str))
+(declare segment (addr int) (size int) (r bool) (w bool) (x bool))
+(declare section (addr int) (size int))
+(declare code-start (addr int))
+(declare named-symbol (addr int) (name str))
+(declare symbol-chunk (addr int) (size int) (root int))
+
+(arch thumb)
+(bits 32)
+(is-little-endian true)
+
+(base-address (addr 0x10000))
+(entry-point (addr 0x102d8))
+
+(mapped (addr 0x103e0) (size 0x20) (off 0x3e0))
+
+(named-region (addr 0x103e0) (size 0x20) (name main))
+
+(code-start (addr 0x103e0))
+(named-symbol (addr 0x103e0) (name main))
+
+(code-region (addr 0x103e0) (size 0x20) (off 0x3e0))
+(symbol-chunk (addr 0x103e0) (size 0x20) (root 0x103e0))

--- a/resources/exes/thumb-simple-compiled/config.json
+++ b/resources/exes/thumb-simple-compiled/config.json
@@ -1,5 +1,6 @@
 {
   "max-tries": 3,
+  "ogre": "loader.ogre",
   "wp-params": {
     "func": "main",
     "postcond" : "(assert (= (bvadd R0_mod #x00000002) R0_orig))"

--- a/resources/exes/thumb-simple-compiled/loader.ogre
+++ b/resources/exes/thumb-simple-compiled/loader.ogre
@@ -1,0 +1,30 @@
+(declare arch (name str))
+(declare bits (size int))
+(declare base-address (addr int))
+(declare entry-point (addr int))
+(declare is-little-endian (flag bool))
+(declare mapped (addr int) (size int) (off int))
+(declare code-region (addr int) (size int) (off int))
+(declare named-region (addr int) (size int) (name str))
+(declare segment (addr int) (size int) (r bool) (w bool) (x bool))
+(declare section (addr int) (size int))
+(declare code-start (addr int))
+(declare named-symbol (addr int) (name str))
+(declare symbol-chunk (addr int) (size int) (root int))
+
+(arch thumb)
+(bits 32)
+(is-little-endian true)
+
+(base-address (addr 0x10000))
+(entry-point (addr 0x102d8))
+
+(mapped (addr 0x103c8) (size 0xc) (off 0x3c8))
+
+(named-region (addr 0x103c8) (size 0xc) (name main))
+
+(code-start (addr 0x103c8))
+(named-symbol (addr 0x103c8) (name main))
+
+(code-region (addr 0x103c8) (size 0xc) (off 0x3c8))
+(symbol-chunk (addr 0x103c8) (size 0xc) (root 0x103c8))

--- a/resources/exes/thumb-simple-multi/config.json
+++ b/resources/exes/thumb-simple-multi/config.json
@@ -1,5 +1,6 @@
 {
   "max-tries": 15,
+  "ogre": "loader.ogre",
   "wp-params": {
     "func": "main",
     "postcond" : "(assert true)"

--- a/resources/exes/thumb-simple-multi/loader.ogre
+++ b/resources/exes/thumb-simple-multi/loader.ogre
@@ -1,0 +1,46 @@
+(declare arch (name str))
+(declare bits (size int))
+(declare base-address (addr int))
+(declare entry-point (addr int))
+(declare is-little-endian (flag bool))
+(declare mapped (addr int) (size int) (off int))
+(declare code-region (addr int) (size int) (off int))
+(declare named-region (addr int) (size int) (name str))
+(declare segment (addr int) (size int) (r bool) (w bool) (x bool))
+(declare section (addr int) (size int))
+(declare code-start (addr int))
+(declare named-symbol (addr int) (name str))
+(declare symbol-chunk (addr int) (size int) (root int))
+
+(arch thumb)
+(bits 32)
+(is-little-endian true)
+
+(base-address (addr 0x10000))
+(entry-point (addr 0x102d8))
+
+(mapped (addr 0x103e0) (size 0x2a) (off 0x3e0))
+(mapped (addr 0x103c8) (size 0xc) (off 0x3c8))
+(mapped (addr 0x103d4) (size 0xc) (off 0x3d4))
+
+(named-region (addr 0x103e0) (size 0x2a) (name main))
+(named-region (addr 0x103c8) (size 0xc) (name f1))
+(named-region (addr 0x103d4) (size 0xc) (name f2))
+
+(code-start (addr 0x103e0))
+(named-symbol (addr 0x103e0) (name main))
+
+(code-start (addr 0x103c8))
+(named-symbol (addr 0x103c8) (name f1))
+
+(code-start (addr 0x103d4))
+(named-symbol (addr 0x103d4) (name f2))
+
+(code-region (addr 0x103e0) (size 0x2a) (off 0x3e0))
+(symbol-chunk (addr 0x103e0) (size 0x2a) (root 0x103e0))
+
+(code-region (addr 0x103c8) (size 0xc) (off 0x3c8))
+(symbol-chunk (addr 0x103c8) (size 0xc) (root 0x103c8))
+
+(code-region (addr 0x103d4) (size 0xc) (off 0x3d4))
+(symbol-chunk (addr 0x103d4) (size 0xc) (root 0x103d4))


### PR DESCRIPTION
This partially fixes the failing tests/bitrot that has happened with recent changes to BAP.

1. We create a property for `Theory.Program.cls` that holds the semantics for the patch program, and then we register a promise to provide this semantics for `Theory.Semantics.cls` . For all program labels that we didn't create specifically for each patch object, this semantics will be empty, so we can avoid any conflicts. @jtpaasch  had this fixed in #204, so I apologize for stealing his thunder in this PR.
2. The skipped test in `test_compiler` is now fixed and it passes.
3. All but one of the system tests are fixed. The Thumb system tests seemed to suffer from program labels having the `:unknown` encoding, perhaps due to a recent change in BAP. To fix this, we manually provide the OGRE file to force BAP to lift the affected code as Thumb.
4. The remaining system test that fails is `arm-bounds-check`. For some reason, the output from Boolector now causes errors in Z3. This should probably be fixed on the WP side instead of VIBES.