### PR TITLE
Adds support for the `init-mem` option in the `wp-params`

### DIFF
--- a/plugin/lib/vibes_plugin_errors.ml
+++ b/plugin/lib/vibes_plugin_errors.ml
@@ -39,6 +39,7 @@ type t =
   | Invalid_perform_verification
   | Invalid_loader_data of string
   | Invalid_bsi_data of string
+  | Invalid_init_mem
   | Loader_data_conflict
   | Invalid_minizinc_isel_filepath
   | Invalid_extra_constraints
@@ -99,6 +100,9 @@ let pp (ppf : Format.formatter) t : unit =
       "error in optional loader data field \"ogre\": " ^ s
     | Invalid_bsi_data s ->
       "error in optional field \"bsi-metadata\": " ^ s
+    | Invalid_init_mem ->
+      "invalid optional `init-mem` field for `wp-params`: must be \
+       `true` or `false`"
     | Loader_data_conflict ->
       "optional fields \"bsi-metadata\" and \"ogre\" were specified, \
        cannot use both"

--- a/plugin/lib/vibes_plugin_errors.mli
+++ b/plugin/lib/vibes_plugin_errors.mli
@@ -42,6 +42,7 @@ type t =
   | Invalid_perform_verification
   | Invalid_loader_data of string
   | Invalid_bsi_data of string
+  | Invalid_init_mem
   | Loader_data_conflict
   | Invalid_minizinc_isel_filepath
   | Invalid_extra_constraints


### PR DESCRIPTION
In some cases we want to tell WP to initialize the read-only memory in the binary, so this provides a field in the config file to do exactly that.

Also, the plugin should be passing the OGRE specification as a filename to WP instead of the actual string contents of the file. Thus, if the BSI metadata field is populated, then we will need to create a temporary file to store the generated OGRE information.