### PR TITLE
Fix compatibility with WP `init-mem` parameter

### DIFF
--- a/bap-vibes/src/patch_c.ml
+++ b/bap-vibes/src/patch_c.ml
@@ -1633,7 +1633,7 @@ let data_of_tgt (target : Theory.target) : Data_model.t KB.t =
     Err.fail @@ Patch_c_error (
       Format.asprintf "Unsupported target %a"
         Theory.Target.pp target) in
-  if Theory.Target.matches target "arm" then
+  if Theory.Target.matches target "arm-family" then
     if Theory.Target.bits target = 32
     then KB.return Data_model.{sizes = `ILP32; schar = false}
     else fail ()

--- a/bap-vibes/src/verifier.ml
+++ b/bap-vibes/src/verifier.ml
@@ -52,8 +52,8 @@ let wp_verifier (p : Params.t) (inputs : Runner.input list) =
 *)
 let verify
     ?(verifier = wp_verifier)
-    ~(orig_prog : Program.t * string * Addr.Set.t)
-    ~(patch_prog : Program.t * string * Addr.Set.t)
+    ~(orig_prog : Program.t * string * Bap_wp.Utils.Code_addrs.t)
+    ~(patch_prog : Program.t * string * Bap_wp.Utils.Code_addrs.t)
     (tgt : Theory.target)
     (params : Params.t) : (next_step, Toplevel_error.t) result =
   let prog1, name1, code1 = orig_prog in

--- a/bap-vibes/src/verifier.ml
+++ b/bap-vibes/src/verifier.ml
@@ -52,18 +52,28 @@ let wp_verifier (p : Params.t) (inputs : Runner.input list) =
 *)
 let verify
     ?(verifier = wp_verifier)
-    ~(orig_prog : Program.t * string)
-    ~(patch_prog : Program.t * string)
+    ~(orig_prog : Program.t * string * Addr.Set.t)
+    ~(patch_prog : Program.t * string * Addr.Set.t)
     (tgt : Theory.target)
     (params : Params.t) : (next_step, Toplevel_error.t) result =
-  let prog1, name1 = orig_prog in
-  let prog2, name2 = patch_prog in
+  let prog1, name1, code1 = orig_prog in
+  let prog2, name2, code2 = patch_prog in
   Events.(send @@ Header "Starting Verifier");
   Events.(send @@ Info "Beginning weakest-precondition analysis...");
   Events.(send @@ Info (sprintf "Original program: %s" name1));
   Events.(send @@ Info (sprintf "Patched program: %s" name2));
-  let input1 = Runner.{program = prog1; target = tgt; filename = name1} in
-  let input2 = Runner.{program = prog2; target = tgt; filename = name2} in
+  let input1 = Runner.{
+      program = prog1;
+      target = tgt;
+      filename = name1;
+      code_addrs = code1;
+    } in
+  let input2 = Runner.{
+      program = prog2;
+      target = tgt;
+      filename = name2;
+      code_addrs = code2;
+    } in
   let* status =
     verifier params [input1; input2] |>
     Result.map_error ~f:(fun e -> Toplevel_error.WP_failure e) in

--- a/bap-vibes/src/verifier.mli
+++ b/bap-vibes/src/verifier.mli
@@ -45,8 +45,8 @@ type next_step = Done | Again
     verifier's results. *)
 val verify :
   ?verifier:(verifier) ->
-  orig_prog:(Program.t * string * Addr.Set.t) ->
-  patch_prog:(Program.t * string * Addr.Set.t) ->
+  orig_prog:(Program.t * string * Utils.Code_addrs.t) ->
+  patch_prog:(Program.t * string * Utils.Code_addrs.t) ->
   Theory.target ->
   Run_parameters.t ->
   (next_step, Toplevel_error.t) result

--- a/bap-vibes/src/verifier.mli
+++ b/bap-vibes/src/verifier.mli
@@ -45,8 +45,8 @@ type next_step = Done | Again
     verifier's results. *)
 val verify :
   ?verifier:(verifier) ->
-  orig_prog:(Program.t * string) ->
-  patch_prog:(Program.t * string) ->
+  orig_prog:(Program.t * string * Addr.Set.t) ->
+  patch_prog:(Program.t * string * Addr.Set.t) ->
   Theory.target ->
   Run_parameters.t ->
   (next_step, Toplevel_error.t) result

--- a/bap-vibes/tests/integration/test_minizinc.ml
+++ b/bap-vibes/tests/integration/test_minizinc.ml
@@ -110,7 +110,7 @@ let ex1 : Ir.t = {
   blks = [blk1]
 }
 
-let arm_tgt = Arm_target.LE.v7
+let arm_tgt = Arm_target.LE.v7a
 let arm_lang = Arm_target.llvm_a32
 
 (* Ensure minizinc produces the expected output on our sample IR block. *)

--- a/bap-vibes/tests/unit/helpers.ml
+++ b/bap-vibes/tests/unit/helpers.ml
@@ -59,9 +59,9 @@ let dummy_code : Cabs.definition =
 
 (* Get an empty program that can be used in tests. *)
 let prog_exn (proj : (Project.t * string, Error.t) result)
-    : Program.t * string =
+    : Program.t * string * Bap_wp.Utils.Code_addrs.t =
   let p, s = proj_exn proj in
-  (Project.program p, s)
+  (Project.program p, s, Bap_wp.Utils.Code_addrs.empty)
 
 (* Some dummy values that can be used in tests. *)
 let the_target () = Theory.Target.read ~package:"bap" "armv7+le"

--- a/bap-vibes/tests/unit/test_parse_c.ml
+++ b/bap-vibes/tests/unit/test_parse_c.ml
@@ -132,7 +132,7 @@ let test_call_hex _ =
     "int temp;
      if (temp == 0) { ((void (*)())0x3ec)(); }"
     "{
-       if (~temp) {
+       if (temp = 0) {
          jmp 0x3EC
        }
      }"
@@ -427,7 +427,7 @@ let test_bool_not _ =
        x = y;
      }"
     "{
-       if (~x) {
+       if (x = 0) {
          x := y
        }
      }"
@@ -437,7 +437,7 @@ let test_mixed_sorts _ =
     "int x, y;
      x += (y == 0);"
     "{
-       x := x + pad:32[~y]
+       x := x + pad:32[y = 0]
      }"
 
 let suite = [

--- a/bap-vibes/tests/unit/test_substituter.ml
+++ b/bap-vibes/tests/unit/test_substituter.ml
@@ -35,7 +35,7 @@ module Test_result = struct
   let result = KB.Class.property ~package cls "test-result" domain
 end
 
-let x86_tgt = Theory.Target.get ~package:"bap" "amd64"
+let x86_tgt = Theory.Target.get ~package:"bap" "x86_64"
 
 (* Very lax equality to avoid tid comparison failures *)
 let eq_elt e1 e2 =

--- a/resources/exes/arm-isel-jmp2/config.json
+++ b/resources/exes/arm-isel-jmp2/config.json
@@ -1,5 +1,5 @@
 {
-  "max-tries": 1,
+  "max-tries": 10,
   "wp-params": {
     "func": "main",
     "postcond": "(assert (= R0_mod #x00000006))"
@@ -21,7 +21,6 @@
      "patch-size" : 128,
      "patch-vars": [
        {"name": "retvar",
-	    "at-entry": "R0",
         "at-exit": "R0"
        }
      ]

--- a/resources/exes/arm-simple-sum/config.json
+++ b/resources/exes/arm-simple-sum/config.json
@@ -1,5 +1,5 @@
 {
-  "max-tries": 1,
+  "max-tries": 10,
   "wp-params": {
     "func": "main",
     "postcond": "(assert (= R0_mod #x00000009))"
@@ -16,7 +16,6 @@
      "patch-size" : 128,
      "patch-vars": [
        {"name": "retvar",
-	    "at-entry": "R0",
         "at-exit": "R0"
        }
      ]


### PR DESCRIPTION
If we're enabling `init-mem` then we need to use the provided utility in `Bap_wp` to collect the known code regions of both binaries.