### PR TITLE
More miscellaneous fixes

### DIFF
--- a/bap-vibes/src/arm_selector.ml
+++ b/bap-vibes/src/arm_selector.ml
@@ -1202,8 +1202,7 @@ module Pretty = struct
         | None -> Result.return @@ First name
         | Some cc -> Result.return @@ Second ("it " ^ C.to_string cc, name)
       else Result.return @@ First name in
-    if String.is_prefix name ~prefix:"bl" then it 2
-    else if String.is_prefix name ~prefix:"mov" then it 3
+    if String.is_prefix name ~prefix:"mov" then it 3
     else Result.return @@ First name
 
   (* We use this function when generating ARM, since the assembler

--- a/bap-vibes/src/arm_selector.ml
+++ b/bap-vibes/src/arm_selector.ml
@@ -1141,9 +1141,10 @@ struct
         | `Def d -> not @@ Tid.Set.mem ignored @@ Term.tid d
         | _ -> true) |> select_elts call_params ~patch ~is_thumb in
     let {current_data; current_ctrl; other_blks} = b_eff in
-    let new_blk = Term.tid b |> Ir.simple_blk
-                    ~data:(List.rev current_data)
-                    ~ctrl:(List.rev current_ctrl) in
+    let new_blk =
+      Term.tid b |> Ir.simple_blk
+        ~data:(List.rev current_data)
+        ~ctrl:(List.rev current_ctrl) in
     let all_blks = Ir.add new_blk other_blks in
     {current_data = []; current_ctrl = []; other_blks = all_blks}
 

--- a/bap-vibes/src/bir_passes.ml
+++ b/bap-vibes/src/bir_passes.ml
@@ -1003,8 +1003,9 @@ end
 (* VIBES IR requires linear SSA form. *)
 let to_linear_ssa
     (patch : Data.Patch.t)
+    (hvars : Higher_var.t list)
     (sub : sub term) : blk term list KB.t =
-  sub |> Sub.ssa |> Linear_ssa.transform ~patch:(Some patch)
+  sub |> Sub.ssa |> Linear_ssa.transform hvars ~patch:(Some patch)
 
 let run
     (patch : Data.Patch.t)
@@ -1060,5 +1061,5 @@ let run
   let* sub = Helper.create_sub ir in
   let cfg = Sub.to_graph sub in
   (* Linear SSA form is needed for VIBES IR. *)
-  let* ir = to_linear_ssa patch sub in
+  let* ir = to_linear_ssa patch hvars sub in
   KB.return {ir; cfg; exclude_regs = String.Set.empty; argument_tids}

--- a/bap-vibes/src/bir_passes.ml
+++ b/bap-vibes/src/bir_passes.ml
@@ -610,9 +610,9 @@ module Shape = struct
       else
         Set.to_list patch_spaces |>
         KB.List.map ~f:(fun space ->
-            let* offset = Data.Patch_space.get_offset_exn space in
+            let* address = Data.Patch_space.get_address_exn space in
             let+ size = Data.Patch_space.get_size_exn space in
-            offset, size) in
+            address, size) in
     List.map patch_spaces ~f:(fun (offset, size) ->
         Word.of_int64 ~width Int64.((offset + size) - 4L))
 

--- a/bap-vibes/src/config.ml
+++ b/bap-vibes/src/config.ml
@@ -48,7 +48,7 @@ type patch =
 
 (** A type to represent known regions that may be overwritten with patch code *)
 type patch_space = {
-    space_offset : int64;
+    space_address : int64;
     space_size : int64
   }
 
@@ -147,7 +147,7 @@ let patches_to_string (ps : patch list) : string =
 let patch_space_to_string (p : patch_space) : string =
   String.concat ~sep:";\n" [
       Printf.sprintf "  {";
-      Printf.sprintf "    Space_offset: %s" (Int64.to_string p.space_offset);
+      Printf.sprintf "    Space_address: %s" (Int64.to_string p.space_address);
       Printf.sprintf "    Space_size: %s" (Int64.to_string p.space_size);
       Printf.sprintf "  }";
     ]

--- a/bap-vibes/src/config.mli
+++ b/bap-vibes/src/config.mli
@@ -29,7 +29,7 @@ type patch_code = CCode of Cabs.definition | ASMCode of string
 
 (** A type to represent known regions that may be overwritten with patch code *)
 type patch_space = {
-    space_offset : int64;
+    space_address : int64;
     space_size : int64
   }
 

--- a/bap-vibes/src/core_c.ml
+++ b/bap-vibes/src/core_c.ml
@@ -350,7 +350,8 @@ module Eval(CT : Theory.Core) = struct
       o !!a !!b
     | VARIABLE (v, _) -> CT.var v
     | CONST_INT (w, _) ->
-      let+ i = CT.int info.word_sort @@ Word.to_bitvec w in
+      let s = T.Bitv.define @@ Word.bitwidth w in
+      let+ i = CT.int s @@ Word.to_bitvec w in
       T.Value.forget i
     | CAST (t, e) ->
       let t' = Patch_c.Exp.typeof e in

--- a/bap-vibes/src/data.ml
+++ b/bap-vibes/src/data.ml
@@ -389,22 +389,22 @@ module Patch_space = struct
   (* This provides equality / comparisons for objects of this class *)
   include (val KB.Object.derive patch_space)
 
-  let offset : (patch_space_cls, int64 option) KB.slot =
-    KB.Class.property ~package patch_space "patch-space-offset" int64_domain
+  let address : (patch_space_cls, int64 option) KB.slot =
+    KB.Class.property ~package patch_space "patch-space-address" int64_domain
 
   let size : (patch_space_cls, int64 option) KB.slot =
     KB.Class.property ~package patch_space "patch-space-size" int64_domain
 
-  let set_offset (obj : t) (data : int64 option) : unit KB.t =
-    KB.provide offset obj data
+  let set_address (obj : t) (data : int64 option) : unit KB.t =
+    KB.provide address obj data
 
-  let get_offset (obj : t) : int64 option KB.t =
-    KB.collect offset obj
+  let get_address (obj : t) : int64 option KB.t =
+    KB.collect address obj
 
-  let get_offset_exn (obj : t) : int64 KB.t =
-    get_offset obj >>= fun result ->
+  let get_address_exn (obj : t) : int64 KB.t =
+    get_address obj >>= fun result ->
     match result with
-    | None -> Kb_error.fail Kb_error.Missing_patch_space_offset
+    | None -> Kb_error.fail Kb_error.Missing_patch_space_address
     | Some value -> KB.return value
 
   let set_size (obj : t) (data : int64 option) : unit KB.t =

--- a/bap-vibes/src/data.mli
+++ b/bap-vibes/src/data.mli
@@ -195,12 +195,12 @@ module Patch_space : sig
   (* equal, compare, and other things for patch spaces *)
   include Knowledge.Object.S with type t := t
 
-  val offset : (patch_space_cls, int64 option) KB.slot
+  val address : (patch_space_cls, int64 option) KB.slot
   val size : (patch_space_cls, int64 option) KB.slot
 
-  val set_offset : t -> int64 option -> unit KB.t
-  val get_offset : t -> int64 option KB.t
-  val get_offset_exn : t -> int64 KB.t
+  val set_address : t -> int64 option -> unit KB.t
+  val get_address : t -> int64 option KB.t
+  val get_address_exn : t -> int64 KB.t
 
   val set_size : t -> int64 option -> unit KB.t
   val get_size : t -> int64 option KB.t

--- a/bap-vibes/src/ir.ml
+++ b/bap-vibes/src/ir.ml
@@ -232,25 +232,13 @@ type t = {
 
 let empty = {blks = []; congruent = []}
 
-(* Preserve the ordering when deduping. This is much slower than `dedup_and_sort`. *)
-let dedup_list_stable l ~compare =
-  let equal x x' = compare x x' = 0 in
-  let rec loop res = function
-    | [] -> res
-    | x :: xs ->
-      let dups = List.find_all_dups (x :: xs) ~compare in
-      let res = if List.mem dups x ~equal then res else x :: res in
-      loop res xs
-  in
-  loop [] (List.rev l)
-
 let union t1 t2 =
   let comp_pair = Tuple.T2.compare ~cmp1:compare_op_var ~cmp2:compare_op_var in
   {
     blks =
-      dedup_list_stable ~compare:compare_blk (t1.blks @ t2.blks);
+      Utils.dedup_list_stable ~compare:compare_blk (t1.blks @ t2.blks);
     congruent =
-      dedup_list_stable ~compare:comp_pair (t1.congruent @ t2.congruent)
+      Utils.dedup_list_stable ~compare:comp_pair (t1.congruent @ t2.congruent)
   }
 
 let add blk t =

--- a/bap-vibes/src/kb_error.ml
+++ b/bap-vibes/src/kb_error.ml
@@ -32,7 +32,7 @@ type t =
   | Missing_patch_size
   | Missing_lower_patch_code
   | Missing_patch_vars
-  | Missing_patch_space_offset
+  | Missing_patch_space_address
   | Missing_patch_space_size
   | Missing_sp_align
   | Missing_func
@@ -76,7 +76,7 @@ let pp ppf (e : t) =
     | Missing_patch_size -> "No patch size was stashed in KB"
     | Missing_lower_patch_code -> "No lower patch code was stashed in KB"
     | Missing_patch_vars -> "No patch vars were stashed in KB"
-    | Missing_patch_space_offset -> "No patch space offset was stashed in KB"
+    | Missing_patch_space_address -> "No patch space address was stashed in KB"
     | Missing_patch_space_size -> "No patch space size was stashed in KB"
     | Missing_sp_align -> "No SP alignment was provided in KB"
     | Missing_func -> "No function name to verify was stashed in KB"

--- a/bap-vibes/src/kb_error.mli
+++ b/bap-vibes/src/kb_error.mli
@@ -34,7 +34,7 @@ type t =
   | Missing_patch_size
   | Missing_lower_patch_code
   | Missing_patch_vars
-  | Missing_patch_space_offset
+  | Missing_patch_space_address
   | Missing_patch_space_size
   | Missing_sp_align
   | Missing_func

--- a/bap-vibes/src/linear_ssa.ml
+++ b/bap-vibes/src/linear_ssa.ml
@@ -253,7 +253,7 @@ let compute_liveness_and_expand_phis
             String.equal (Naming.mark_reg_name reg) @@
             Var.name @@ Var.base v in
           (* For each higher var we intended to finalize, add them
-             to the set out live outs for this block. *)
+             to the set of live outs for this block. *)
           List.fold hvars ~init:outs ~f:(fun outs -> function
               | {value = Registers ({at_exit = Some reg; _}); _} -> begin
                   match Seq.find vars ~f:(same reg) with

--- a/bap-vibes/src/linear_ssa.ml
+++ b/bap-vibes/src/linear_ssa.ml
@@ -50,8 +50,9 @@ let orig_name (name : string) : string option =
   let* name = match String.split name ~on:'_' with
     | [] -> Some name
     | [name] when not @@ String.is_empty name -> Some name
-    | [name; _] -> Some name
-    | _ -> None
+    | l ->
+      let* l = List.drop_last l in
+      Some (String.concat l ~sep:"_")
   in
   if is_reg then Some (Naming.mark_reg_name name) else Some name
 

--- a/bap-vibes/src/linear_ssa.ml
+++ b/bap-vibes/src/linear_ssa.ml
@@ -203,6 +203,7 @@ let linearize_blk (blk : blk term) : blk term linear =
    edges in the CFG.
 *)
 let compute_liveness_and_expand_phis
+    (hvars : Higher_var.t list)
     (sub : sub term) : (blk term list * Data.ins_outs Tid.Map.t) KB.t =
   let open KB.Let in
   let liveness = Live.compute sub in
@@ -237,6 +238,30 @@ let compute_liveness_and_expand_phis
   let ins_outs_map = List.map blks ~f:(fun blk ->
       let tid = Term.tid blk in
       let outs = Live.outs liveness tid in
+      let outs =
+        (* Implicit exit blocks will have the `at-exit` finalizers,
+           if they exist. *)
+        if Bir_helpers.is_implicit_exit blk then
+          (* Get all of the finalizers, which are assignments to
+             preassigned registers. *)
+          let vars =
+            Term.enum def_t blk |> Seq.map ~f:Def.lhs |>
+            Seq.filter ~f:(fun v -> Option.is_some @@ Naming.unmark_reg v) in
+          (* Compare the higher var storage information with the
+             existing var. We need the SSA'd name of this var. *)
+          let same reg v =
+            String.equal (Naming.mark_reg_name reg) @@
+            Var.name @@ Var.base v in
+          (* For each higher var we intended to finalize, add them
+             to the set out live outs for this block. *)
+          List.fold hvars ~init:outs ~f:(fun outs -> function
+              | {value = Registers ({at_exit = Some reg; _}); _} -> begin
+                  match Seq.find vars ~f:(same reg) with
+                  | Some v -> Set.add outs v
+                  | None -> outs
+                end
+              | _ -> outs)
+        else outs in
       let ins = Live.ins liveness tid in
       let prefix = prefix_from blk in
       let outs = Var.Set.map outs ~f:(fun var -> linearize ~prefix var) in
@@ -252,9 +277,10 @@ let all_ins_outs_vars (ins_outs : Data.ins_outs Tid.Map.t) : Var.Set.t =
 
 let transform
     ?(patch : Data.Patch.t option = None)
+    (hvars : Higher_var.t list)
     (sub : sub term) : blk term list KB.t =
   let open KB.Let in
-  let* blks, ins_outs_map = compute_liveness_and_expand_phis sub in
+  let* blks, ins_outs_map = compute_liveness_and_expand_phis hvars sub in
   let blks, Linear.Env.{vars; _} =
     Linear.(run (List.map blks ~f:linearize_blk) Env.empty) in
   (* Add in live variables that persist across blocks that don't use them *)

--- a/bap-vibes/src/linear_ssa.mli
+++ b/bap-vibes/src/linear_ssa.mli
@@ -52,4 +52,8 @@ val congruent : Var.t -> Var.t -> bool
 
 (** [tranform s] takes the subroutine [s] and converts it into the linear
     SSA form described above, returning the blocks only. *)
-val transform : ?patch:Data.Patch.t option -> Sub.t -> Blk.t list KB.t
+val transform :
+  ?patch:Data.Patch.t option ->
+  Higher_var.t list ->
+  Sub.t ->
+  Blk.t list KB.t

--- a/bap-vibes/src/minizinc.ml
+++ b/bap-vibes/src/minizinc.ml
@@ -236,7 +236,8 @@ let serialize_mzn_params
   let temp_names =
     List.map ~f:(fun t -> Var.to_string t) temps
   in
-  let hvars = List.filter_map temps ~f:(fun temp -> Linear_ssa.orig_name (Var.to_string temp)) in
+  let hvars = List.filter_map temps ~f:(fun temp ->
+      Linear_ssa.orig_name (Var.to_string temp)) in
   let hvars = String.Set.to_list @@ String.Set.of_list hvars in
   let* class_t =
     key_map_kb operands params.class_

--- a/bap-vibes/src/patcher.ml
+++ b/bap-vibes/src/patcher.ml
@@ -499,7 +499,10 @@ let patch
   let base_address =
     match Ogre.eval (Ogre.require Image.Scheme.base_address) spec with
     | Ok addr -> addr
-    | Error _ -> 0L in
+    | Error _ ->
+      Events.send @@ Info
+        "Warning: base-address was not found in the OGRE specification";
+      0L in
   let* original_exe_filename = Data.Original_exe.get_filepath_exn obj in
   let* original_exe_unit = Theory.Unit.for_file original_exe_filename in
   let* patches = Data.Patched_exe.get_patches obj in

--- a/bap-vibes/src/patcher.ml
+++ b/bap-vibes/src/patcher.ml
@@ -94,19 +94,14 @@ let check_for_literal_pool (l : Theory.language) (assembly : string list)
   let with_elf_filename = Stdlib.Filename.temp_file "vibes-assembly" ".o" in
   (* FIXME: a bit hacky, we should have a dictionary here probably. *)
   let tgt_flag = tgt_flag l in
-  let args =
-    [
-      "-o";
-      with_elf_filename;
-      tgt_flag;
-      asm_filename
-    ]
-  in
-  let info_str =
-    Format.asprintf "Calling %s %s..."
-      assembler
-      (String.concat ~sep:" " args)
-  in
+  let args = [
+    "-o";
+    with_elf_filename;
+    tgt_flag;
+    asm_filename
+  ] in
+  let info_str = Format.asprintf "Calling %s %s..."
+      assembler @@ String.concat ~sep:" " args in
   Events.(send @@ Info info_str);
   let* _ = Utils.run_process assembler args in
   let literal = size_of_literal_pool l with_elf_filename in
@@ -118,14 +113,12 @@ let binary_of_elf (with_elf_filename : string) : (string, Kb_error.t) Result.t =
   (* strip elf data *)
   let objcopy = "/usr/bin/arm-linux-gnueabi-objcopy" in
   let raw_bin_filename = Stdlib.Filename.temp_file "vibes-assembly" ".bin" in
-  let objcopy_args =
-    [
-      "-O";
-      "binary";
-      with_elf_filename;
-      raw_bin_filename
-    ]
-  in
+  let objcopy_args = [
+    "-O";
+    "binary";
+    with_elf_filename;
+    raw_bin_filename
+  ] in
   let* _ = Utils.run_process objcopy objcopy_args in
   let patch_exe = In.read_all raw_bin_filename in
   Ok patch_exe
@@ -141,11 +134,11 @@ let binary_of_elf (with_elf_filename : string) : (string, Kb_error.t) Result.t =
 let jmp_instr_size : int64 = 4L
 
 
-(** [build_patch] returns the binary of a patch with athe appropriate jumps *)
+(** [build_patch] returns the binary of a patch with the appropriate jumps *)
 let build_patch
     (l : Theory.language)
     (patch : placed_patch)
-  : (int64 * string, Kb_error.t) Result.t =
+    (base_address : int64) : (int64 * string, Kb_error.t) Result.t =
   let (let*) x f = Result.bind x ~f in
   (* [abs_jmp] produces assembly for an unconditional jmp *)
   let abs_jmp (abs_addr : int64) : string =
@@ -159,7 +152,7 @@ let build_patch
     | Some j -> abs_jmp Int64.(j - patch.patch_loc)
   in
   let patch_loc = Printf.sprintf ".equiv %s, %Ld\n"
-      Constants.patch_location patch.patch_loc in
+      Constants.patch_location Int64.(patch.patch_loc + base_address) in
   let patch_start = Printf.sprintf "%s:" Constants.patch_start_label in
   let org = match patch.org_offset with
     | Some off -> Printf.sprintf ".org %d" off
@@ -176,7 +169,7 @@ let build_patch
   Result.return (literal, bin)
 
 let patch_size (l : Theory.language) (patch : patch)
-  : (int64 * int64, Kb_error.t) Result.t =
+    (base_address : int64) : (int64 * int64, Kb_error.t) Result.t =
   let placed_patch = {
     assembly = patch.assembly;
     orig_loc = patch.orig_loc;
@@ -185,7 +178,7 @@ let patch_size (l : Theory.language) (patch : patch)
     jmp = None;
     org_offset = None;
   } in
-  build_patch l placed_patch |>
+  build_patch l placed_patch base_address |>
   Result.map ~f:(fun (literal, b) ->
       String.length b |> Int64.of_int, literal)
 
@@ -194,7 +187,7 @@ let patch_size (l : Theory.language) (patch : patch)
 let patch_file (lang : Theory.language)
     ~filename:(original_exe_filename : string)
     (patches : placed_patch list)
-  : string =
+    (base_address : int64) : string =
   let tmp_patched_exe_filename =
     Stdlib.Filename.temp_file "vibes-assembly" ".patched" in
   let orig_exe = In.read_all original_exe_filename in
@@ -205,7 +198,7 @@ let patch_file (lang : Theory.language)
           ~f:(fun patch ->
               Out.seek file patch.patch_loc;
               let patch_binary =
-                build_patch lang patch |>
+                build_patch lang patch base_address |>
                 Result.map_error ~f:(Format.asprintf "%a" Kb_error.pp) |>
                 Result.ok_or_failwith |> snd in 
               (* Shave off the extra bytes at the beginning if we shifted
@@ -270,6 +263,7 @@ let loose_fit_patch ?(org_offset : int option = None)
     the jump to the patch that goes where the original code was.  The
     second is the patch itself. *)
 let external_patch_site
+    ?(org_offset : int option = None)
     (patch : patch)
     (patch_loc : int64) : placed_patch * placed_patch =
   let open Int64 in
@@ -282,14 +276,15 @@ let external_patch_site
   let placed_patch = {
     placed_patch with
     patch_loc = patch_loc;
-    jmp = Some (patch.orig_size + patch.orig_loc)
+    jmp = Some (patch.orig_size + patch.orig_loc);
+    org_offset;
   } in
   (jmp_to_patch, placed_patch)
 
 (** [find_site_greedy] goes through a [patch_site] list and finds the
-   first one in which a patch of size [patch_size] can fit. It then
-   returns the address of this site and a modified [patch_site] list
-   with those locations removed.*)
+    first one in which a patch of size [patch_size] can fit. It then
+    returns the address of this site and a modified [patch_site] list
+    with those locations removed.*)
 let find_site_greedy (patch_sites : patch_site list) (patch_size : int64)
   : int64 * patch_site list =
   let open Int64 in
@@ -311,65 +306,75 @@ let find_site_greedy (patch_sites : patch_site list) (patch_size : int64)
   in
   find_site_aux patch_sites
 
-(** [place_patches] given patches and patch_sites, find a way to split and pack patches
-    At the moment it is just greedy.
+(* If we have a literal pool in the patch, then objcopy may insert extra
+   padding if it determines that an unaligned memory access is possible. 
+   We need to anticipate this by telling the assembler that our patch will
+   be at some offset from the origin. We will then fix up the code once
+   we actually insert the patch into the new binary.
+
+   Consider the following cases in a Thumb binary (ARM doesn't apply to
+   this problem since everything is always aligned by the same boundary):
+
+   1) Our patch is inserted at an address that is aligned by 2 (but not 4):
+
+      a) If the patch ends on an address that is aligned by 4, then the
+         size of our patch has a remainder of 2. Therefore, padding will
+         be inserted between our patch code and the literal pool. Since
+         the start of our patch is misaligned, we need to adjust the
+         origin such that all PC-relative offsets end up the same as if
+         our patch was inserted at an aligned boundary.
+
+      b) Otherwise, the patch ends on an address that is aligned by 2,
+         so the assembler will incorrectly insert padding between our
+         patch and the literal pool. Therefore, we need to adjust the
+         origin of our patch for the assembler.
+
+   2) Our patch is inserted at an address that is aligned by 4. Whether
+      or not padding is inserted by the assembler, we have a relative
+      starting position of 0, so objcopy won't insert padding behind our
+      backs, and thus our PC-relative offsets remain consistent.
+*)
+let calc_org_offset (has_literal : bool) (loc : int64) (align : int64) =
+  let open Int64 in
+  if has_literal then
+    (* Is the patch location aligned? *)
+    let align_loc = rem loc align in
+    if align_loc <> 0L then Some (to_int_exn align_loc) else None
+  else None
+
+(** [place_patches] given patches and patch_sites, find a way to split and
+    pack patches. At the moment it is just greedy.
 *)
 let place_patches
     (tgt : Theory.target)
     (lang : Theory.language)
+    (base_address : int64)
     (patches : patch list)
     (patch_sites : patch_site list) : placed_patch list =
   let open Int64 in
   let align = (Theory.Target.code_alignment tgt |> of_int) lsr 3 in
+  let is_thumb =
+    String.is_substring ~substring:"thumb" @@
+    Theory.Language.to_string lang in
   let process_patch (acc, patch_sites) patch =
     let patch_size, literal =
-      patch_size lang patch |> Result.ok |> Option.value_exn in
-    Events.send @@ Info (
-      sprintf "Patch %s, size = %Ld\n%!"
-        patch.name Int64.(literal + patch_size));
+      patch_size lang patch base_address |> Result.ok |> Option.value_exn in
+    (* If there is a literal pool, it should count for taking up space
+       when placing the patch. *)
+    let patch_size = patch_size + literal in
     let has_literal = literal <> 0L in
-    let org_offset =
-      (* If we have a literal pool in the patch, then objcopy may insert extra
-         padding if it determines that an unaligned memory access is possible. 
-         We need to anticipate this by telling the assembler that our patch will
-         be at some offset from the origin. We will then fix up the code once
-         we actually insert the patch into the new binary.
-
-         Consider the following cases in a Thumb binary (ARM doesn't apply to
-         this problem since everything is always aligned by the same boundary):
-
-         1) Our patch is inserted at an address that is aligned by 2 (but not 4):
-
-            a) If the patch ends on an address that is aligned by 4, then the
-               size of our patch has a remainder of 2. Therefore, padding will
-               be inserted between our patch code and the literal pool. Since
-               the start of our patch is misaligned, we need to adjust the
-               origin such that all PC-relative offsets end up the same as if
-               our patch was inserted at an aligned boundary.
-
-            b) Otherwise, the patch ends on an address that is aligned by 2,
-               so the assembler will incorrectly insert padding between our
-               patch and the literal pool. Therefore, we need to adjust the
-               origin of our patch for the assembler.
-
-         2) Our patch is inserted at an address that is aligned by 4. Whether
-            or not padding is inserted by the assembler, we have a relative
-            starting position of 0, so objcopy won't insert padding behind our
-            backs, and thus our PC-relative offsets remain consistent.
-      *)
-      if has_literal then
-        (* Is the patch location aligned? *)
-        let align_loc = rem patch.orig_loc align in
-        if align_loc <> 0L then Some (to_int_exn align_loc) else None
-      else None in
     (* If a literal pool was inserted at the end, then we need to insert
        a jump. *)
     if has_literal then
       Events.send @@ Info "Found literal pool at end of patch.";
     let patch_size =
+      (* Regardless of whether the patch fits or not, we have to jump
+         over the literal pool. *)
       if has_literal then patch_size + jmp_instr_size else patch_size in
-    if patch_size <= patch.orig_size (* Patch fits inplace *)
-    then
+    if patch_size <= patch.orig_size then begin (* Patch fits inplace *)
+      let org_offset = calc_org_offset has_literal patch.orig_loc align in
+      Events.send @@ Info (
+        sprintf "Patch %s, size = %Ld\n%!" patch.name patch_size);
       (* If patch exactly fits *)
       if patch_size = patch.orig_size then
         let exact = exact_fit_patch patch ~org_offset in
@@ -382,23 +387,36 @@ let place_patches
         let placed_patch, new_patch_site =
           loose_fit_patch patch (patch_size - jmp_instr_size) ~org_offset in
         (placed_patch :: acc, new_patch_site :: patch_sites)
-    else (* Patch does not fit inplace*)
-      (* Find patch_site that works *)
+    end else begin (* Patch does not fit inplace*)
       let patch_size =
+        (* We need a jump regardless of whether there was a literal pool
+           or not. *)
         if not has_literal then patch_size + jmp_instr_size else patch_size in
-      let (patch_loc, patch_sites) = find_site_greedy patch_sites patch_size in
-      let (jmp_to_patch, placed_patch) = external_patch_site patch patch_loc in
+      (* HACK: conservatively estimate that, if we're using an external patch
+         site, then it's far away enough that the branch will be relaxed from 2
+         to 4 bytes by the assembler. *)
+      let patch_size =
+        if is_thumb then
+          let bs =
+            of_int @@ List.length @@
+            List.filter patch.assembly ~f:(fun s ->
+                String.is_substring s "b (patch_start_label")  in
+          patch_size + 2L * bs
+        else patch_size in
+      Events.send @@ Info (
+        sprintf "Patch %s, size = %Ld\n%!" patch.name patch_size);
+      (* Find patch_site that works *)
+      let patch_loc, patch_sites = find_site_greedy patch_sites patch_size in
+      let org_offset = calc_org_offset has_literal patch_loc align in
+      let jmp_to_patch, placed_patch =
+        external_patch_site patch patch_loc ~org_offset in
       (* TODO: We could also insert the unused original space into
          patch_sites here. *)
       (jmp_to_patch :: placed_patch  :: acc , patch_sites)
-  in
-  let (placed_patches, _) =
-    List.fold patches
-      ~init:([], patch_sites)
-      ~f:process_patch
-  in
-  placed_patches
-
+    end in
+  fst @@ List.fold patches
+    ~init:([], patch_sites)
+    ~f:process_patch
 
 (* A datatype that encodes the code region that shall contain the placed patch.
    Usually computed by an invocation to ogre on the [Image.Scheme.code_region]
@@ -406,13 +424,14 @@ let place_patches
 *)
 type patch_region = { region_addr : int64; region_offset : int64 }
 
-let ogre_compute_region ~loc:(patch_point : int64) (spec : Ogre.doc) : patch_region Or_error.t =
+let ogre_compute_region (spec : Ogre.doc)
+    ~loc:(patch_point : int64) : patch_region Or_error.t =
   let code_region =
     Ogre.eval
       (Ogre.require
          ~that:Int64.(fun (addr,size,_) ->
              addr <= patch_point && patch_point <= addr + size)
-   Image.Scheme.code_region) spec
+         Image.Scheme.code_region) spec
   in
   Or_error.map code_region
     ~f:(fun (addr, _size, offset) ->
@@ -430,20 +449,14 @@ let reify_patch
     ~exe_unit:(exe_unit)
     (patch : Data.Patch.t) : patch KB.t =
   let open KB.Let in
-  let* name = Data.Patch.get_patch_name_exn patch in
+  let* name = Data.Patch.get_patch_name patch in
+  let name = Option.value name ~default:"unnamed-patch" in
   let* patch_point = Data.Patch.get_patch_point_exn patch in
-  let* addr = Theory.Label.for_addr patch_point in
-  let* unit = KB.collect Theory.Label.unit addr in
-  let* unit = match unit with
-    | None -> KB.return exe_unit
-    | Some x -> KB.return x
-  in
-  let* spec = KB.collect Image.Spec.slot unit in
   let patch_point = Bitvec.to_int64 patch_point in
-  let patch_region = compute_region ~loc:patch_point spec in
+  let patch_region = compute_region ~loc:patch_point in
   let* {region_addr; region_offset} = match patch_region with
-  | Error s -> Kb_error.fail (Kb_error.Other (Core_kernel.Error.to_string_hum s))
-  | Ok c -> KB.return c
+    | Error s -> Kb_error.fail @@ Other (Core_kernel.Error.to_string_hum s)
+    | Ok c -> KB.return c
   in
   (* The distance of patch address from region start address is calculated
      and then added to the region file offset to get the patch file offset *)
@@ -459,15 +472,18 @@ let reify_patch
 
 (* Turn a KB patch space into a patch site (the type used by this module to
    represent the same information *)
-let reify_patch_site (obj : Data.Patch_space.t) : patch_site KB.t =
+let reify_patch_site (obj : Data.Patch_space.t)
+    (base_address : int64) : patch_site KB.t =
   let open KB.Let in
-  let* location = Data.Patch_space.get_offset_exn obj in
+  let* location = Data.Patch_space.get_address_exn obj in
+  let location = Int64.(location - base_address) in
   let* size = Data.Patch_space.get_size_exn obj in
   KB.return {location; size}
 
 (* Get the patch_spaces out of the kb monad and into the form used by this
    module *)
-let reify_patch_sites (obj : Data.t) : patch_site list KB.t =
+let reify_patch_sites (obj : Data.t)
+    (base_address : int64) : patch_site list KB.t =
   let open KB.Let in
   let* patch_space_set : Data.Patch_space_set.t =
     Data.Original_exe.get_patch_spaces obj
@@ -475,28 +491,33 @@ let reify_patch_sites (obj : Data.t) : patch_site list KB.t =
   let patch_spaces : Data.Patch_space.t list =
     Data.Patch_space_set.to_list patch_space_set
   in
-  KB.List.map ~f:reify_patch_site patch_spaces
+  KB.List.map patch_spaces ~f:(fun o ->
+      reify_patch_site o base_address)
 
 (* Patches the original exe, to produce a patched exe. *)
 let patch
     ?compute_region:(compute_region=ogre_compute_region)
     ?patcher:(patcher=patch_file)
-    (obj : Data.t) : unit KB.t =
+    (obj : Data.t)
+    (spec : Ogre.doc) : unit KB.t =
   let open KB.Let in
   Events.(send @@ Header "Starting patcher");
   (* Get patch information (the address to start patching and the number
      of bytes to overwrite), and get the patch assembly. *)
   Events.(send @@ Info "Retrieving data from KB...");
-
+  let base_address =
+    match Ogre.eval (Ogre.require Image.Scheme.base_address) spec with
+    | Ok addr -> addr
+    | Error _ -> 0L in
   let* original_exe_filename = Data.Original_exe.get_filepath_exn obj in
   let* original_exe_unit = Theory.Unit.for_file original_exe_filename in
   let* patches = Data.Patched_exe.get_patches obj in
   let patch_list = Data.Patch_set.to_list patches in
-  let reify_patch = reify_patch
-    ~compute_region:compute_region ~exe_unit:original_exe_unit in
+  let compute_region = compute_region spec in
+  let reify_patch = reify_patch ~compute_region ~exe_unit:original_exe_unit in
   let* patch_list = KB.List.map ~f:reify_patch patch_list in
   let naive_patch_sites = naive_find_patch_sites original_exe_filename in
-  let* provided_patch_sites = reify_patch_sites obj in
+  let* provided_patch_sites = reify_patch_sites obj base_address in
   let patch_sites = naive_patch_sites @ provided_patch_sites in
   let* target =
     let patch = Data.Patch_set.choose_exn patches in
@@ -505,14 +526,22 @@ let patch
     let patch = Data.Patch_set.choose_exn patches in
     Data.Patch.get_lang patch in
   Events.(send @@ Info "Found Patch Sites:");
-  Events.(send @@ Info (Format.asprintf "%a" Sexp.pp_hum @@ sexp_of_list sexp_of_patch_site patch_sites));
+  Events.(send @@ Info (
+      Format.asprintf "%a" Sexp.pp_hum @@
+      sexp_of_list sexp_of_patch_site patch_sites));
   Events.(send @@ Info "Solving patch placement...");
-  let placed_patches = place_patches target lang patch_list patch_sites in
+  let placed_patches =
+    place_patches target lang base_address patch_list patch_sites in
   Events.(send @@ Info "Patch Placement Solution:");
-  Events.(send @@ Info (Format.asprintf "%a" Sexp.pp_hum @@ sexp_of_list sexp_of_placed_patch placed_patches));
+  Events.(send @@ Info (
+      Format.asprintf "%a" Sexp.pp_hum @@
+      sexp_of_list sexp_of_placed_patch placed_patches));
   Events.(send @@ Info "Patching file...");
-  let tmp_patched_exe_filename = patcher lang ~filename:original_exe_filename placed_patches in
-
+  let tmp_patched_exe_filename =
+    patcher lang ~filename:original_exe_filename
+      placed_patches base_address in
   (* Stash the filepath in the KB. *)
-  let* _ = Data.Patched_exe.set_tmp_filepath obj (Some tmp_patched_exe_filename) in
+  let* _ =
+    Data.Patched_exe.set_tmp_filepath obj @@
+    Some tmp_patched_exe_filename in
   KB.return ()

--- a/bap-vibes/src/patcher.mli
+++ b/bap-vibes/src/patcher.mli
@@ -62,14 +62,23 @@ type placed_patch = {
    patch *region* within a binary *)
 type patch_region = {
   region_addr : int64;
-  region_offset : int64
+  region_offset : int64;
 }
+
+type compute_region = Ogre.doc -> loc:int64 -> patch_region Or_error.t
+
+type patcher =
+  Theory.language ->
+  filename:string ->
+  placed_patch list ->
+  int64 ->
+  string
 
 (** [patch ~patcher obj spec] uses the [patcher] function to patch the original
     executable associated with the provided [obj]. *)
 val patch :
-  ?compute_region:(Ogre.doc -> loc:int64 -> patch_region Or_error.t) ->
-  ?patcher:(Theory.language -> filename:string -> placed_patch list -> int64 -> string) ->
+  ?compute_region:compute_region ->
+  ?patcher:patcher ->
   Data.t ->
   Ogre.doc ->
   unit KB.t

--- a/bap-vibes/src/patcher.mli
+++ b/bap-vibes/src/patcher.mli
@@ -23,6 +23,7 @@ open Bap_core_theory
 module KB = Knowledge
 
 type patch = {
+  name : string;
   assembly : string list;
   orig_loc : int64;
   orig_size : int64;

--- a/bap-vibes/src/patcher.mli
+++ b/bap-vibes/src/patcher.mli
@@ -65,17 +65,19 @@ type patch_region = {
   region_offset : int64
 }
 
-(** [patch ~patcher obj] uses the [patcher] function to patch the original
+(** [patch ~patcher obj spec] uses the [patcher] function to patch the original
     executable associated with the provided [obj]. *)
 val patch :
-  ?compute_region:(loc:int64 -> Ogre.doc -> patch_region Or_error.t) ->
-  ?patcher:(Theory.language -> filename:string -> placed_patch list -> string) ->
+  ?compute_region:(Ogre.doc -> loc:int64 -> patch_region Or_error.t) ->
+  ?patcher:(Theory.language -> filename:string -> placed_patch list -> int64 -> string) ->
   Data.t ->
+  Ogre.doc ->
   unit KB.t
 
 val place_patches :
   Theory.target ->
   Theory.language ->
+  int64 ->
   patch list ->
   patch_site list ->
   placed_patch list

--- a/bap-vibes/src/pipeline.ml
+++ b/bap-vibes/src/pipeline.ml
@@ -45,7 +45,8 @@ let create_patched_exe ~seed:(seed : Seeder.t) (config : Config.t)
     (proj : project) : Data.t KB.t =
   let* obj = Seeder.init_KB config proj ~seed:(Some seed) in
   let* () = Compiler.compile_assembly obj in
-  let* () = Patcher.patch obj in
+  let spec = Project.specification proj in
+  let* () = Patcher.patch obj spec in
   KB.return obj
 
 (* Each time we produce a patch, we give it a tmp filepath. This function

--- a/bap-vibes/src/seeder.ml
+++ b/bap-vibes/src/seeder.ml
@@ -117,7 +117,7 @@ let create_patch_spaces (patch_spaces : Config.patch_space list)
   let create_patch_space (ps : Config.patch_space) =
     let* obj = KB.Object.create Data.Patch_space.patch_space in
     let* () =
-      Data.Patch_space.set_offset obj (Some (Config.(ps.space_offset)))
+      Data.Patch_space.set_address obj (Some (Config.(ps.space_address)))
     in
     let* () =
       Data.Patch_space.set_size obj (Some (Config.(ps.space_size)))

--- a/bap-vibes/src/utils.ml
+++ b/bap-vibes/src/utils.ml
@@ -159,3 +159,14 @@ let print_c (pp : 'a -> unit) (data : 'a) : string =
   Cprint.out := old_chan;
   Stdlib.Sys.remove tmp_file;
   res
+
+(* Preserve the ordering when deduping. This is much slower than `dedup_and_sort`. *)
+let dedup_list_stable l ~compare =
+  let equal x x' = compare x x' = 0 in
+  let rec loop res = function
+    | [] -> res
+    | x :: xs ->
+      let dups = Base.List.find_all_dups (x :: xs) ~compare in
+      let res = if Base.List.mem dups x ~equal then res else x :: res in
+      loop res xs in
+  loop [] (List.rev l)

--- a/bap-vibes/src/utils.ml
+++ b/bap-vibes/src/utils.ml
@@ -157,5 +157,5 @@ let print_c (pp : 'a -> unit) (data : 'a) : string =
     |> String.concat ~sep:"\n"
   in
   Cprint.out := old_chan;
-  Sys.remove tmp_file;
+  Stdlib.Sys.remove tmp_file;
   res

--- a/bap-vibes/src/utils.mli
+++ b/bap-vibes/src/utils.mli
@@ -51,3 +51,7 @@ val get_target : addr:Bitvec.t -> Theory.target KB.t
     first argument on the second, and returns whatever string is in the
     [Cprint.out] channel.  *)
 val print_c : ('a -> unit) -> 'a -> string
+
+(** [dedup_list_stable l ~compare] removes all duplicates from [l] according
+    to [compare] while preserving the original order in [l]. *)
+val dedup_list_stable : 'a list -> compare:('a -> 'a -> int) -> 'a list

--- a/bap-vibes/tests/unit/test_arm_selector.ml
+++ b/bap-vibes/tests/unit/test_arm_selector.ml
@@ -375,7 +375,7 @@ let test_ir13 ctxt =
   test_ir ctxt Prog13.prog [blk_pat ^ ":"; "ldrh R0, \\[R0\\]"]
 
 let test_ir14 ctxt =
-  test_ir ctxt Prog14.prog [blk_pat ^ ":"; "bl some_function"]
+  test_ir ctxt Prog14.prog [blk_pat ^ ":"; "bl some_function"; "b " ^ blk_pat]
 
 let test_ir15 ctxt =
   test_ir ctxt Prog15.prog [blk_pat ^ ":"; "add R0, R0, #42"]

--- a/bap-vibes/tests/unit/test_linear_ssa.ml
+++ b/bap-vibes/tests/unit/test_linear_ssa.ml
@@ -96,7 +96,7 @@ let test_transform (_ : test_ctxt) : unit =
   let computation =
     let open KB.Syntax in
     KB.Object.create Dummy_kb.cls >>= fun obj ->
-    Linear_ssa.transform sub >>= fun blks ->
+    Linear_ssa.transform [] sub >>= fun blks ->
     KB.provide Dummy_kb.blks obj (Some blks) >>= fun () ->
     KB.return obj in
   let result =  match KB.run Dummy_kb.cls computation KB.empty with

--- a/plugin/lib/vibes_plugin_parameters.ml
+++ b/plugin/lib/vibes_plugin_parameters.ml
@@ -230,18 +230,20 @@ let validate_patch_space (obj : Json.t)
   let top_level_err = Errors.Invalid_patch_spaces
     "Each item in the patch-space list must be a JSON object."
   in
-  let offset_err = Errors.Invalid_patch_spaces
-    "Error parsing `offset` field, which must be a bitvector string."
+  let address_err = Errors.Invalid_patch_spaces
+    "Error parsing `address` field, which must be a bitvector string."
   in
   let size_err = Errors.Invalid_patch_spaces
     "Error parsing `size` field, which must be an integer string."
   in
   match obj with
   | `Assoc data ->
-     validate_int64_field "offset" data offset_err >>= fun offset ->
+     validate_int64_field "address" data address_err >>= fun address ->
      validate_int64_field "size" data size_err >>= fun size ->
-     Err.return { Vibes_config.space_offset = offset ;
-                  Vibes_config.space_size = size }
+     Err.return Vibes_config.{
+       space_address = address;
+       space_size = size;
+     }
   | _ -> Err.fail top_level_err
 
 (* Extract and validate the patch_space list, or error. *)

--- a/resources/exes/arm-bounds-check/config.json
+++ b/resources/exes/arm-bounds-check/config.json
@@ -21,7 +21,7 @@
                 (select init_mem_mod base))))))))"
   },
   "patch-space": [
-    {"offset": "0x510",
+    {"address": "0x10510",
      "size": "512"
     }
   ],

--- a/resources/exes/arm-branch/config.json
+++ b/resources/exes/arm-branch/config.json
@@ -14,7 +14,7 @@
     {"patch-name" : "ret-3",
      "patch-code" : "int temp;
                      if (temp == 0)
-                        { goto L_0x3ec; }",
+                        { goto L_0x103ec; }",
      "patch-point" : "0x103dc",
      "patch-size" : 8}
   ]

--- a/resources/exes/arm-patch-call/config.json
+++ b/resources/exes/arm-patch-call/config.json
@@ -6,7 +6,7 @@
   },
   "patches" : [
     {"patch-name" : "ret-3",
-     "patch-code" : "((void (*)())0x3c8)();",
+     "patch-code" : "((void (*)())0x103c8)();",
      "patch-point" : "0x10408",
      "patch-size" : 4
     }

--- a/resources/exes/thumb-patch-space/config.json
+++ b/resources/exes/thumb-patch-space/config.json
@@ -6,7 +6,7 @@
   },
   "ogre": "loader.ogre",
   "patch-space" : [
-    {"offset" : "0x3c8",
+    {"address" : "0x103c8",
      "size" : "24"}
   ],
   "patches" : [


### PR DESCRIPTION
1. The current instruction selector was ignoring the return destination, e.g.: `call x with return %00001234`, hoping that `blk00001234` is the immediate next block in the generated assembly code.  I've run into a case where this assumption is broken, so we'll now insert an explicit branch to this location, hoping that the peephole optimizer can get rid of it later.
2. `Linear_ssa.orig_name` was incorrectly rejecting variable names with underscores in them, so if you wanted to refer to them in, say, the extra Minizinc constraints, then they wouldn't appear there.
3. The patcher should output the inferred sizes of each patch, by name. Feels right to inform the user about it.
4. The handling of constant integers in the C frontend needed some fixing. By default, they are the same size as `Theory.Target.bits` for the target machine (so for ARM this is 32 bits).  However, if we want to use them in, say, a binary operation with a smaller-sized expression, e.g. `unsigned char x, y; y = x + 5;`, then this would cause a type error later down the line during the BIR passes (the `Simpl` pass does some type checking on the code). The constant `5` in this case should be shaved down to an 8-bit integer. 
5. Also, the sizes of constants was being ignored in the `Core_c` pass, so I fixed that (again to prevent type errors).