### PR TITLE
Moves the attributes to a separate section when serializing

### DIFF
--- a/vibes-tools/resources/patch.2.bir
+++ b/vibes-tools/resources/patch.2.bir
@@ -1,14 +1,16 @@
-(patch.2.bir
- ((%00000021 block (phi ())
-   (data
-    ((%0000000f set (x 0 (imm 32) false) (int 3:32u))
-     (%00000012 set (y 0 (imm 32) false) (int 6:32u))
-     (%00000015 set (reg:R0 0 (imm 32) false) (var (x 0 (imm 32) false)))
-     (%00000018 set (reg:R1 0 (imm 32) false) (var (y 0 (imm 32) false)))))
-   (ctrl
-    ((%0000001a call (direct %0000000a) (return (direct %0000001d))
-      (when (int 1:1u))))))
-  (%0000001d block (phi ())
-   (data
-    ((%0000001e set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
-   (ctrl ()))))
+(program
+ (patch.2.bir
+  ((%00000021 block (phi ())
+    (data
+     ((%0000000f set (x 0 (imm 32) false) (int 3:32u))
+      (%00000012 set (y 0 (imm 32) false) (int 6:32u))
+      (%00000015 set (reg:R0 0 (imm 32) false) (var (x 0 (imm 32) false)))
+      (%00000018 set (reg:R1 0 (imm 32) false) (var (y 0 (imm 32) false)))))
+    (ctrl
+     ((%0000001a call (direct %0000000a) (return (direct %0000001d))
+       (when (int 1:1u))))))
+   (%0000001d block (phi ())
+    (data
+     ((%0000001e set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
+    (ctrl ()))))
+ (attrs ()))

--- a/vibes-tools/resources/patch.2.opt.bir
+++ b/vibes-tools/resources/patch.2.opt.bir
@@ -1,18 +1,20 @@
-(patch.2.bir
- ((%0000000b block (phi ())
-   (data
-    ((%0000000d set (reg:R0 0 (imm 32) false) (int 3:32u)
-      (attrs (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))
-     (%0000000c set (reg:R1 0 (imm 32) false) (int 6:32u)
-      (attrs (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))
-     (%00000013 set (mem:call 0 (mem 32 8) false)
-      (var (mem 0 (mem 32 8) false))
-      (attrs (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))))
-   (ctrl
-    ((%00000010 call (direct %00000011) (return (direct %00000009))
-      (when (int 1:1u))))))
-  (%00000009 block (phi ())
-   (data
-    ((%0000000a set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
-   (ctrl ((%00000014 goto (direct %00000015) (when (int 1:1u))))))
-  (%00000015 block (phi ()) (data ()) (ctrl ()))))
+(program
+ (patch.2.bir
+  ((%0000000b block (phi ())
+    (data
+     ((%0000000d set (reg:R0 0 (imm 32) false) (int 3:32u))
+      (%0000000c set (reg:R1 0 (imm 32) false) (int 6:32u))
+      (%00000013 set (mem:call 0 (mem 32 8) false)
+       (var (mem 0 (mem 32 8) false)))))
+    (ctrl
+     ((%00000010 call (direct %00000011) (return (direct %00000009))
+       (when (int 1:1u))))))
+   (%00000009 block (phi ())
+    (data
+     ((%0000000a set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
+    (ctrl ((%00000014 goto (direct %00000015) (when (int 1:1u))))))
+   (%00000015 block (phi ()) (data ()) (ctrl ()))))
+ (attrs
+  ((%0000000c (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
+   (%0000000d (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
+   (%00000013 (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))))

--- a/vibes-tools/resources/patch.bir
+++ b/vibes-tools/resources/patch.bir
@@ -1,3 +1,5 @@
-(patch.bir
- ((%0000000d block (phi ())
-   (data ((%0000000c set (x 0 (imm 32) false) (int 3:32u)))) (ctrl ()))))
+(program
+ (patch.bir
+  ((%0000000d block (phi ())
+    (data ((%0000000c set (x 0 (imm 32) false) (int 3:32u)))) (ctrl ()))))
+ (attrs ()))

--- a/vibes-tools/resources/patch.opt.bir
+++ b/vibes-tools/resources/patch.opt.bir
@@ -1,7 +1,9 @@
-(patch.bir
- ((%00000009 block (phi ())
-   (data
-    ((%0000000a set (mem 0 (mem 32 8) false)
-      (store (var (mem 0 (mem 32 8) false)) (int 0xBEEF:32u) (int 3:32u)
-       LittleEndian 32))))
-   (ctrl ()))))
+(program
+ (patch.bir
+  ((%00000009 block (phi ())
+    (data
+     ((%0000000a set (mem 0 (mem 32 8) false)
+       (store (var (mem 0 (mem 32 8) false)) (int 0xBEEF:32u) (int 3:32u)
+        LittleEndian 32))))
+    (ctrl ()))))
+ (attrs ()))


### PR DESCRIPTION
When they're littered throughout the program terms it tends to make the serialized output unreadable, which goes against a major design goal we have.

We still have the ugly UUID strings, but at least they're separated from the part that the user may be hand-editing.