### PR TITLE
Use the bitvector type for patch space addresses

### DIFF
--- a/vibes-tools/tools/vibes-opt/lib/shape.ml
+++ b/vibes-tools/tools/vibes-opt/lib/shape.ml
@@ -155,7 +155,8 @@ let collect_conservative_patch_points
         Bitvec.to_int64 bv in
       [patch_point, patch_info.patch_size]
     | spaces -> List.map spaces ~f:(fun space ->
-        (space.address, space.size)) in
+        let address = Bitvec.to_int64 @@ Word.to_bitvec space.address in
+        (address, space.size)) in
   List.map patch_spaces ~f:(fun (offset, size) ->
       Word.of_int64 ~width Int64.((offset + size) - 4L))
 

--- a/vibes-tools/tools/vibes-patch-info/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.ml
@@ -3,7 +3,7 @@ module Utils = Vibes_utils
 module Hvar = Vibes_higher_vars.Higher_var
 
 type space = {
-  address : int64 [@key "address"]; 
+  address : Utils.Json.Bitvector.t [@key "address"];
   size : int64 [@key "size"];
 } [@@deriving yojson]
 

--- a/vibes-tools/tools/vibes-patch-info/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.mli
@@ -7,7 +7,7 @@ open Bap_core_theory
     - [size]: the size of the patch space
 *)
 type space = {
-  address : int64;
+  address : Vibes_utils.Json.Bitvector.t;
   size : int64;
 } [@@deriving yojson]
 


### PR DESCRIPTION
It's more natural to use hex notation in JSON to describe these fields, but JSON doesn't support it, so we need to use a different datatype.