### PR TITLE
Miscellaneous fixes to `vibes-tools`

### DIFF
--- a/vibes-tools/resources/example-as-2.bash
+++ b/vibes-tools/resources/example-as-2.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-as \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --vir-filepath resources/patch.2.vir \
   --asm-outfile resources/patch.2.asm \

--- a/vibes-tools/resources/example-as.bash
+++ b/vibes-tools/resources/example-as.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-as \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --vir-filepath resources/patch.vir \
   --asm-outfile resources/patch.asm \

--- a/vibes-tools/resources/example-opt-2.bash
+++ b/vibes-tools/resources/example-opt-2.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-opt \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --function-info-filepath resources/patch.2.func.info \
   --patch-info-filepath resources/patch-info.2.json \

--- a/vibes-tools/resources/example-opt.bash
+++ b/vibes-tools/resources/example-opt.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-opt \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --function-info-filepath resources/patch.func.info \
   --patch-info-filepath resources/patch-info.json \

--- a/vibes-tools/resources/example-parse-2.bash
+++ b/vibes-tools/resources/example-parse-2.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-parse \
-  --target bap:arm \
+  --target bap:armv7+le \
   --patch-info-filepath resources/patch-info.2.json \
   --patch-filepath resources/patch.2.c \
   --bir-outfile resources/patch.2.bir \

--- a/vibes-tools/resources/example-parse.bash
+++ b/vibes-tools/resources/example-parse.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-parse \
-  --target bap:arm \
+  --target bap:armv7+le \
   --patch-info-filepath resources/patch-info.json \
   --patch-filepath resources/patch.c \
   --bir-outfile resources/patch.bir \

--- a/vibes-tools/resources/example-select-2.bash
+++ b/vibes-tools/resources/example-select-2.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-select \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --patch-info-filepath resources/patch-info.2.json \
   --bir-filepath resources/patch.2.opt.bir \

--- a/vibes-tools/resources/example-select.bash
+++ b/vibes-tools/resources/example-select.bash
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 cd "${ROOT_DIR}"
 
 vibes-select \
-  --target bap:arm \
+  --target bap:armv7+le \
   --language llvm-armv7 \
   --patch-info-filepath resources/patch-info.json \
   --bir-filepath resources/patch.opt.bir \

--- a/vibes-tools/resources/patch.asm
+++ b/vibes-tools/resources/patch.asm
@@ -1,4 +1,4 @@
 ((directives (".syntax unified"))
  (blocks
   (((label blk00000019)
-    (insns ("movw R9, #48879" "mov R11, #3" "str R11, [R9]"))))))
+    (insns ("movw R9, #48879" "mov R8, #3" "str R8, [R9]"))))))

--- a/vibes-tools/tools/vibes-as/lib/dune
+++ b/vibes-tools/tools/vibes-as/lib/dune
@@ -3,6 +3,7 @@
 (library
  (name vibes_as)
  (public_name vibes-as)
+ (flags -w -32)
  (libraries
    bap-core-theory
    vibes-log

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -1622,7 +1622,7 @@ let data_of_tgt (target : Theory.target) : Data_model.t KB.t =
   let fail () =
     fail @@ Format.asprintf "Unsupported target %a"
       Theory.Target.pp target in
-  if Theory.Target.matches target "arm" then
+  if Theory.Target.belongs Arm_target.parent target then
     if Theory.Target.bits target = 32
     then KB.return Data_model.{sizes = `ILP32; schar = false}
     else fail ()

--- a/vibes-tools/tools/vibes-ir/lib/types.mli
+++ b/vibes-tools/tools/vibes-ir/lib/types.mli
@@ -142,7 +142,7 @@ val all_opcodes : t -> opcode list
 val definer_map : t -> Opvar.t Var.Map.t                         
 val users_map : t -> Opvar.t list Var.Map.t
 
-val opvar_to_preassign : t -> var id_map
+val opvar_to_preassign : t -> var option id_map
 val temp_to_block : t -> tid Var.Map.t
 val operation_to_opcodes : t -> opcode list id_map
 val operand_to_operation : t -> Operation.t id_map

--- a/vibes-tools/tools/vibes-opt/lib/opt.ml
+++ b/vibes-tools/tools/vibes-opt/lib/opt.ml
@@ -33,8 +33,8 @@ module Builtin : S = struct
     }
 
     let updated_term = Value.Tag.register (module Unit)
-        ~name:"vibes-updated-term"
-        ~uuid:"98dce3a9-3831-452c-a7b7-4d26f23ad23e"
+        ~name:"vibes:updated-term"
+        ~uuid:"9c116f9f-ac35-4514-91f2-569109563b5c"
 
     let mark_updated t = Term.set_attr t updated_term ()
     let is_updated t = Option.is_some (Term.get_attr t updated_term)

--- a/vibes-tools/tools/vibes-patch/bin/main.ml
+++ b/vibes-tools/tools/vibes-patch/bin/main.ml
@@ -42,7 +42,7 @@ module Cli = struct
 
   let ogre_filepath : string option C.Term.t =
     let info = C.Arg.info ["O"; "ogre"]
-        ~docv:"OGRE_FILEPATH"
+        ~docv:"OGRE"
         ~doc:"Path/name of the optional OGRE loader file. It must \
               be an absolute filepath, e.g. ./myloader.ogre" in
     let parser = C.Arg.some' C.Arg.string in


### PR DESCRIPTION
1. The check for target matching `arm` in `Patch_c` is wrong.
2. The optimization for removing empty blocks should only happen for those blocks that are unreferenced (e.g. it is the target of a jump).
3. The calculation of the `width` parameter for the MiniZinc model was wrong, leading to incorrect solutions.