### PR TITLE
Re-adds ability to ingest multiple patches and extra constraints

### DIFF
--- a/vibes-tools/resources/example-as-2.bash
+++ b/vibes-tools/resources/example-as-2.bash
@@ -10,4 +10,5 @@ vibes-as \
   --vir-filepath resources/patch.2.vir \
   --asm-outfile resources/patch.2.asm \
   --model ../resources/minizinc/model.mzn  \
+  --patch-info-filepath resources/patch-info.2.json \
   --verbose

--- a/vibes-tools/resources/example-as.bash
+++ b/vibes-tools/resources/example-as.bash
@@ -10,4 +10,5 @@ vibes-as \
   --vir-filepath resources/patch.vir \
   --asm-outfile resources/patch.asm \
   --model ../resources/minizinc/model.mzn  \
+  --patch-info-filepath resources/patch-info.json \
   --verbose

--- a/vibes-tools/resources/patch-info.json
+++ b/vibes-tools/resources/patch-info.json
@@ -2,7 +2,6 @@
   "patch-point": "0x10400:32",
   "patch-size": 2,
   "sp-align": 0,
-  "patch-spaces": [],
   "patch-vars": [
     {
       "name": "index",

--- a/vibes-tools/resources/patch.2.asm
+++ b/vibes-tools/resources/patch.2.asm
@@ -1,4 +1,4 @@
-((directives (".syntax unified"))
+((patch_point 66560) (patch_size 2) (directives (".syntax unified"))
  (blocks
   (((label blk0000001b)
     (insns

--- a/vibes-tools/resources/patch.2.bir
+++ b/vibes-tools/resources/patch.2.bir
@@ -1,16 +1,16 @@
 (program
  (patch.2.bir
-  ((%00000021 block (phi ())
+  ((%00000031 block (phi ())
     (data
-     ((%0000000f set (x 0 (imm 32) false) (int 3:32u))
-      (%00000012 set (y 0 (imm 32) false) (int 6:32u))
-      (%00000015 set (reg:R0 0 (imm 32) false) (var (x 0 (imm 32) false)))
-      (%00000018 set (reg:R1 0 (imm 32) false) (var (y 0 (imm 32) false)))))
+     ((%0000001f set (x 0 (imm 32) false) (int 3:32u))
+      (%00000022 set (y 0 (imm 32) false) (int 6:32u))
+      (%00000025 set (reg:R0 0 (imm 32) false) (var (x 0 (imm 32) false)))
+      (%00000028 set (reg:R1 0 (imm 32) false) (var (y 0 (imm 32) false)))))
     (ctrl
-     ((%0000001a call (direct %0000000a) (return (direct %0000001d))
+     ((%0000002a call (direct %0000001a) (return (direct %0000002d))
        (when (int 1:1u))))))
-   (%0000001d block (phi ())
+   (%0000002d block (phi ())
     (data
-     ((%0000001e set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
+     ((%0000002e set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
     (ctrl ()))))
  (attrs ()))

--- a/vibes-tools/resources/patch.2.func.info
+++ b/vibes-tools/resources/patch.2.func.info
@@ -1,1 +1,1 @@
-{"functions":[{"label":"%0000000a","name":"foo","addr":null,"args":["reg:R0","reg:R1"]}]}
+{"functions":[{"label":"%0000001a","name":"foo","addr":null,"args":["reg:R0","reg:R1"]}]}

--- a/vibes-tools/resources/patch.2.opt.bir
+++ b/vibes-tools/resources/patch.2.opt.bir
@@ -1,20 +1,20 @@
 (program
  (patch.2.bir
-  ((%0000000b block (phi ())
+  ((%0000001b block (phi ())
     (data
-     ((%0000000d set (reg:R0 0 (imm 32) false) (int 3:32u))
-      (%0000000c set (reg:R1 0 (imm 32) false) (int 6:32u))
-      (%00000013 set (mem:call 0 (mem 32 8) false)
+     ((%0000001d set (reg:R0 0 (imm 32) false) (int 3:32u))
+      (%0000001c set (reg:R1 0 (imm 32) false) (int 6:32u))
+      (%00000023 set (mem:call 0 (mem 32 8) false)
        (var (mem 0 (mem 32 8) false)))))
     (ctrl
-     ((%00000010 call (indirect (int 0x1234:32u)) (return (direct %00000009))
+     ((%00000020 call (indirect (int 0x1234:32u)) (return (direct %00000019))
        (when (int 1:1u))))))
-   (%00000009 block (phi ())
+   (%00000019 block (phi ())
     (data
-     ((%0000000a set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
-    (ctrl ((%00000014 goto (direct %00000015) (when (int 1:1u))))))
-   (%00000015 block (phi ()) (data ()) (ctrl ()))))
+     ((%0000001a set (z 0 (imm 32) false) (var (reg:R0 0 (imm 32) false)))))
+    (ctrl ((%00000024 goto (direct %00000025) (when (int 1:1u))))))
+   (%00000025 block (phi ()) (data ()) (ctrl ()))))
  (attrs
-  ((%0000000c (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
-   (%0000000d (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
-   (%00000013 (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))))
+  ((%0000001c (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
+   (%0000001d (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ())))
+   (%00000023 (("2ecbeae4-a576-406c-b95c-324083406c85:vibes\\:argument" ()))))))

--- a/vibes-tools/resources/patch.2.vir
+++ b/vibes-tools/resources/patch.2.vir
@@ -1,16 +1,16 @@
 (program
- ((%0000000d
+ ((%0000001d
    (data
     ((4
       (lhs
        ((var
-         (opvar 3 ((_0000000d_reg:R0_1 0 (imm 32) false))
+         (opvar 3 ((_0000001d_reg:R0_1 0 (imm 32) false))
           ((R0 0 (imm 32) false))))))
       (opcodes (mov)) (optional false) (operands ((const 3:32u))))
      (6
       (lhs
        ((var
-         (opvar 5 ((_0000000d_reg:R1_1 0 (imm 32) false))
+         (opvar 5 ((_0000001d_reg:R1_1 0 (imm 32) false))
           ((R1 0 (imm 32) false))))))
       (opcodes (mov)) (optional false) (operands ((const 6:32u))))))
    (ctrl
@@ -18,42 +18,42 @@
       (optional false)
       (operands
        ((offset 0x1234:32u)
-        (void (opvar 8 ((_0000000d_mem 0 (mem 32 8) false)) ()))
+        (void (opvar 8 ((_0000001d_mem 0 (mem 32 8) false)) ()))
         (var
-         (opvar 9 ((_0000000d_reg:R1_1 0 (imm 32) false))
+         (opvar 9 ((_0000001d_reg:R1_1 0 (imm 32) false))
           ((R1 0 (imm 32) false))))
         (var
-         (opvar 10 ((_0000000d_reg:R0_1 0 (imm 32) false))
+         (opvar 10 ((_0000001d_reg:R0_1 0 (imm 32) false))
           ((R0 0 (imm 32) false)))))))
      (13 (lhs ((void (opvar 12 ((#1 0 (imm 1) true)) ())))) (opcodes (b))
-      (optional false) (operands ((label %0000000a))))))
-   (ins (15 ((void (opvar 26 ((_0000000d_mem 0 (mem 32 8) false)) ())))))
+      (optional false) (operands ((label %0000001a))))))
+   (ins (15 ((void (opvar 26 ((_0000001d_mem 0 (mem 32 8) false)) ())))))
    (outs
     (14
      ((var
-       (opvar 27 ((_0000000d_reg:R0_1 0 (imm 32) false))
+       (opvar 27 ((_0000001d_reg:R0_1 0 (imm 32) false))
         ((R0 0 (imm 32) false)))))))
    (frequency 1))
-  (%0000000a
+  (%0000001a
    (data
-    ((19 (lhs ((var (opvar 17 ((_0000000a_z_1 0 (imm 32) false)) ()))))
+    ((19 (lhs ((var (opvar 17 ((_0000001a_z_1 0 (imm 32) false)) ()))))
       (opcodes (mov)) (optional false)
       (operands
        ((var
-         (opvar 18 ((_0000000a_reg:R0_1 0 (imm 32) false))
+         (opvar 18 ((_0000001a_reg:R0_1 0 (imm 32) false))
           ((R0 0 (imm 32) false)))))))))
    (ctrl
     ((21 (lhs ((void (opvar 20 ((#2 0 (imm 1) true)) ())))) (opcodes (b))
-      (optional false) (operands ((label %00000009))))))
+      (optional false) (operands ((label %00000019))))))
    (ins
     (23
      ((var
-       (opvar 28 ((_0000000a_reg:R0_1 0 (imm 32) false))
+       (opvar 28 ((_0000001a_reg:R0_1 0 (imm 32) false))
         ((R0 0 (imm 32) false)))))))
    (outs (22 ())) (frequency 1))
-  (%00000009 (data ()) (ctrl ()) (ins (25 ())) (outs (24 ())) (frequency 1)))
+  (%00000019 (data ()) (ctrl ()) (ins (25 ())) (outs (24 ())) (frequency 1)))
  (congruences
-  (((_0000000a_reg:R0_1 0 (imm 32) false)
-    ((_0000000d_reg:R0_1 0 (imm 32) false)))
-   ((_0000000d_reg:R0_1 0 (imm 32) false)
-    ((_0000000a_reg:R0_1 0 (imm 32) false))))))
+  (((_0000001a_reg:R0_1 0 (imm 32) false)
+    ((_0000001d_reg:R0_1 0 (imm 32) false)))
+   ((_0000001d_reg:R0_1 0 (imm 32) false)
+    ((_0000001a_reg:R0_1 0 (imm 32) false))))))

--- a/vibes-tools/resources/patch.asm
+++ b/vibes-tools/resources/patch.asm
@@ -1,4 +1,4 @@
-((directives (".syntax unified"))
+((patch_point 66560) (patch_size 2) (directives (".syntax unified"))
  (blocks
   (((label blk00000019)
     (insns ("movw R9, #48879" "mov R8, #3" "str R8, [R9]"))))))

--- a/vibes-tools/resources/patch.bir
+++ b/vibes-tools/resources/patch.bir
@@ -1,5 +1,5 @@
 (program
  (patch.bir
-  ((%0000000d block (phi ())
-    (data ((%0000000c set (x 0 (imm 32) false) (int 3:32u)))) (ctrl ()))))
+  ((%0000001d block (phi ())
+    (data ((%0000001c set (x 0 (imm 32) false) (int 3:32u)))) (ctrl ()))))
  (attrs ()))

--- a/vibes-tools/resources/patch.opt.bir
+++ b/vibes-tools/resources/patch.opt.bir
@@ -1,8 +1,8 @@
 (program
  (patch.bir
-  ((%00000009 block (phi ())
+  ((%00000019 block (phi ())
     (data
-     ((%0000000a set (mem 0 (mem 32 8) false)
+     ((%0000001a set (mem 0 (mem 32 8) false)
        (store (var (mem 0 (mem 32 8) false)) (int 0xBEEF:32u) (int 3:32u)
         LittleEndian 32))))
     (ctrl ()))))

--- a/vibes-tools/tools/vibes-as/bin/main.ml
+++ b/vibes-tools/tools/vibes-as/bin/main.ml
@@ -41,22 +41,36 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.required arg
 
+  let extra_constraints_filepath : string option C.Term.t =
+    let info = C.Arg.info ["extra-constraints"]
+        ~docv:"EXTRA_CONSTRAINTS"
+        ~doc:"Optional path/name of file containing extra MiniZinc \
+              constraints" in
+    let parser = C.Arg.some' C.Arg.string in
+    let default = None in
+    let arg = C.Arg.opt parser default info in
+    C.Arg.value arg
+
   let run
       (verbose : bool)
       (no_color : bool)
       (target : string)
       (language : string)
+      (patch_info_filepath : string)
       (vir_filepath : string)
       (asm_outfile : string)
-      (model_filepath : string) : (unit, string) result =
+      (model_filepath : string)
+      (extra_constraints_filepath : string option) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
     Log.send "Running 'vibes-as'";
     Runner.run
       ~target
       ~language
       ~vir_filepath
+      ~patch_info_filepath
       ~asm_outfile
-      ~model_filepath |> function
+      ~model_filepath
+      ~extra_constraints_filepath |> function
     | Ok () -> Ok ()
     | Error e -> Error (KB.Conflict.to_string e)
 
@@ -66,9 +80,11 @@ module Cli = struct
       $ Cli_opts.Verbosity.no_color
       $ Cli_opts.Target.target
       $ Cli_opts.Language.language
+      $ Cli_opts.Patch_info.filepath
       $ vir_filepath
       $ asm_outfile
       $ model_filepath
+      $ extra_constraints_filepath
     )
 
   let cmd = C.Cmd.v info runner

--- a/vibes-tools/tools/vibes-as/lib/runner.ml
+++ b/vibes-tools/tools/vibes-as/lib/runner.ml
@@ -9,6 +9,7 @@ module Files = Vibes_utils.Files
 module Log = Vibes_log.Stream
 module Serializers = Vibes_serializers
 module Ir = Vibes_ir.Types
+module Patch_info = Vibes_patch_info.Types
 
 let (let*) x f = Result.bind x ~f
 
@@ -20,15 +21,24 @@ let try_deserialize (vir_sexp : Sexp.t) : (Ir.t, KB.conflict) result =
   with Toplevel.Conflict err -> Error err
 
 let run
+    ?(extra_constraints_filepath : string option = None)
     ~(target : string)
     ~(language : string)
     ~(vir_filepath : string)
+    ~(patch_info_filepath : string)
     ~(asm_outfile : string)
     ~(model_filepath : string) : (unit, KB.conflict) result =
-  Log.send "Vibes_as.Runner.run '%s' '%s' '%s' '%s' '%s'"
-    target language vir_filepath asm_outfile model_filepath;
+  Log.send "Vibes_as.Runner.run '%s' '%s' '%s' '%s' '%s' '%s' '%s'"
+    target language vir_filepath patch_info_filepath asm_outfile
+    model_filepath (Option.value extra_constraints_filepath ~default:"(none)");
   let* target = CT.get_target target in
   let* language = CT.get_language language in
+  let* patch_info = Patch_info.from_file patch_info_filepath in
+  let* constraints = match extra_constraints_filepath with
+    | None -> Ok None
+    | Some path ->
+      let* constraints = Files.get_file_contents path in
+      Ok (Some constraints) in
   let* raw_vir_code = Files.get_file_contents_non_empty vir_filepath
       ~error:(fun s -> Errors.No_vir (
           Format.sprintf "No serialized VIR in file '%s'" s)) in
@@ -40,10 +50,10 @@ let run
     | _ -> Error (Errors.Invalid_vir "Expected single S-exp") in
   let* ir = try_deserialize vir_sexp in
   Log.send "Deserialized VIBES IR:\n%a\n" Ir.pp ir;
-  let* ir = Solver.solve ir target language model_filepath in
+  let* ir = Solver.solve ir target language model_filepath ~constraints in
   Log.send "Solved VIBES IR:\n%a\n" Ir.pp ir;
   let* printer = Utils.asm_printer target language in
-  let* asm = printer ir in
+  let* asm = printer ir patch_info in
   Log.send "Assembly:\n%a\n" Types.Assembly.pp asm;
   let asm_sexp = Types.Assembly.sexp_of_t asm in
   let asm_data = Sexp.to_string_hum asm_sexp in

--- a/vibes-tools/tools/vibes-as/lib/runner.mli
+++ b/vibes-tools/tools/vibes-as/lib/runner.mli
@@ -3,9 +3,11 @@ open Bap_core_theory
 (** Generates assembly for the VIBES IR program according to
     the MiniZinc model. *)
 val run :
+  ?extra_constraints_filepath:string option ->
   target:string ->
   language:string ->
   vir_filepath:string ->
+  patch_info_filepath:string ->
   asm_outfile:string ->
   model_filepath:string ->
   (unit, KB.conflict) result

--- a/vibes-tools/tools/vibes-as/lib/solver.ml
+++ b/vibes-tools/tools/vibes-as/lib/solver.ml
@@ -28,11 +28,15 @@ let opt
     ~unconditional_branch_target
 
 let solve
+    ?(constraints : string option = None)
     (ir : Ir.t)
     (target : T.target)
     (language : T.language)
     (model_filepath : string) : (Ir.t, KB.conflict) result =
   let* params, info = Params.serialize ir target language in
+  let model_filepath =
+    Option.value_map constraints ~default:model_filepath
+      ~f:(Minizinc.build_constraints_file ~model_filepath) in
   let* solution_filepath = Minizinc.run_minizinc params ~model_filepath in
   let* solution = Solution.deserialize solution_filepath info in
   let ir = Solution.apply ir solution in

--- a/vibes-tools/tools/vibes-as/lib/solver.mli
+++ b/vibes-tools/tools/vibes-as/lib/solver.mli
@@ -1,10 +1,15 @@
 open Bap_core_theory
 open Vibes_ir.Types
 
-(** [solve ir target language model_filepath] runs MiniZinc on the [ir]
-    program according to the model in [model_filepath], and returns the
-    optimized program. *)
+(** [solve ir target language model_filepath ?constraints] runs MiniZinc
+    on the [ir] program according to the model in [model_filepath], and
+    returns the optimized program.
+
+    An optional specification of extra [constraints] can be provided as
+    a raw string.
+*)
 val solve :
+  ?constraints:string option ->
   t ->
   Theory.target ->
   Theory.language ->

--- a/vibes-tools/tools/vibes-as/lib/types.ml
+++ b/vibes-tools/tools/vibes-as/lib/types.ml
@@ -9,11 +9,16 @@ module Assembly = struct
   } [@@deriving fields, sexp]
 
   type t = {
+    patch_point : int64;
+    patch_size : int64;
     directives : string list;
     blocks : block list;
   } [@@deriving fields, sexp]
 
-  type printer = Vibes_ir.Types.t -> (t, KB.conflict) result
+  type printer =
+    Vibes_ir.Types.t ->
+    Vibes_patch_info.Types.t ->
+    (t, KB.conflict) result
 
   let pp_block (ppf : Format.formatter) (blk : block) : unit =
     Format.fprintf ppf "%s:\n%!" blk.label;

--- a/vibes-tools/tools/vibes-as/lib/types.mli
+++ b/vibes-tools/tools/vibes-as/lib/types.mli
@@ -11,13 +11,18 @@ module Assembly : sig
 
   (** An assembly program. *)
   type t = {
+    patch_point : int64;
+    patch_size : int64;
     directives : string list;
     blocks : block list;
   } [@@deriving fields, sexp]
 
   (** A printer will take a VIBES IR program and return the assembly
       representation if it is well-formed. *)
-  type printer = Vibes_ir.Types.t -> (t, KB.conflict) result
+  type printer =
+    Vibes_ir.Types.t ->
+    Vibes_patch_info.Types.t ->
+    (t, KB.conflict) result
 
   (** [pp ppf asm] will pretty-print the [asm] program to formatter
       [ppf]. *)

--- a/vibes-tools/tools/vibes-common-cli-options/lib/patch_info.ml
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/patch_info.ml
@@ -2,9 +2,18 @@ module C = Cmdliner
 
 let filepath : string C.Term.t =
   let info = C.Arg.info ["p"; "patch-info-filepath"]
-    ~docv:"PATCH_INFO_FILEPATH"
-    ~doc:"Filepath containing patch info (JSON)" in
+      ~docv:"PATCH_INFO_FILEPATH"
+      ~doc:"Filepath containing patch info (JSON)" in
   let parser = C.Arg.some' C.Arg.string in
   let default = None in
   let arg = C.Arg.opt parser default info in
   C.Arg.required arg
+
+let spaces : string option C.Term.t =
+  let info = C.Arg.info ["patch-spaces"]
+      ~docv:"PATCH_SPACES"
+      ~doc:"Filepath containing external patch spaces (JSON)" in
+  let parser = C.Arg.some' C.Arg.string in
+  let default = None in
+  let arg = C.Arg.opt parser default info in
+  C.Arg.value arg

--- a/vibes-tools/tools/vibes-common-cli-options/lib/patch_info.mli
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/patch_info.mli
@@ -1,2 +1,5 @@
-(** A filepath. *)
+(** Filepath for the patch info. *)
 val filepath : string Cmdliner.Term.t
+
+(** Filepath for the external patch spaces. *)
+val spaces : string option Cmdliner.Term.t

--- a/vibes-tools/tools/vibes-minizinc/lib/utils.ml
+++ b/vibes-tools/tools/vibes-minizinc/lib/utils.ml
@@ -5,6 +5,15 @@ module Filename = Stdlib.Filename
 module Proc = Vibes_utils.Proc
 module Log = Vibes_log.Stream
 
+let build_constraints_file
+    (constraints : string)
+    ~(model_filepath : string) : string =
+  let wrapper_filepath = Filename.temp_file "vibes-mzn-model" ".mzn" in
+  let outc = Out_channel.create wrapper_filepath in
+  Out_channel.fprintf outc "include \"%s\";\n%s" model_filepath constraints;
+  Out_channel.close outc;
+  wrapper_filepath
+
 let run_minizinc
     (params : Yojson.Safe.t)
     ~(model_filepath : string) : (string, KB.conflict) result =

--- a/vibes-tools/tools/vibes-minizinc/lib/utils.mli
+++ b/vibes-tools/tools/vibes-minizinc/lib/utils.mli
@@ -1,5 +1,14 @@
 open Bap_core_theory
 
+(** [build_constraints_file constraints ~model_filepath] creates a
+    temporary file containing the extra constraints based on the
+    existing model at [model_filepath]. The path to the temporary
+    file is returned. *)
+val build_constraints_file :
+  string ->
+  model_filepath:string ->
+  string
+
 (** [run_minizinc params ~model_filepath] runs the MiniZinc process on
     the parameters [params] according to the model at [model_filepath].
 

--- a/vibes-tools/tools/vibes-opt/bin/main.ml
+++ b/vibes-tools/tools/vibes-opt/bin/main.ml
@@ -45,6 +45,7 @@ module Cli = struct
       (target : string)
       (language : string)
       (patch_info_filepath : string)
+      (patch_spaces : string option)
       (bir_filepath : string)
       (func_info_filepath : string)
       (bir_outfile : string) : (unit, string) result =
@@ -54,6 +55,7 @@ module Cli = struct
       ~target
       ~language
       ~patch_info_filepath
+      ~patch_spaces
       ~bir_filepath
       ~func_info_filepath
       ~bir_outfile |> function
@@ -67,6 +69,7 @@ module Cli = struct
       $ Cli_opts.Target.target
       $ Cli_opts.Language.language
       $ Cli_opts.Patch_info.filepath
+      $ Cli_opts.Patch_info.spaces
       $ bir_filepath
       $ func_info_filepath
       $ bir_outfile

--- a/vibes-tools/tools/vibes-opt/lib/bir_passes.ml
+++ b/vibes-tools/tools/vibes-opt/lib/bir_passes.ml
@@ -64,12 +64,15 @@ let provide_function_info
                   end else !!())))
 
 let thumb_specific
+    ?(patch_spaces : Patch_info.spaces = [])
     (sub : sub term)
     ~(target : T.target)
     ~(patch_info : Patch_info.t) : sub term KB.t =
   Log.send "Relaxing branches";
   let* sub = Shape.relax_branches sub
-      ~target ~patch_info ~fwd_limit:0xFFFFE ~bwd_limit:0x100000 in
+      ~target ~patch_info ~patch_spaces
+      ~fwd_limit:0xFFFFE
+      ~bwd_limit:0x100000 in
   log_sub sub;
   Log.send "Splitting conditional jumps";
   let+ sub = Shape.split_on_conditional sub in
@@ -77,6 +80,7 @@ let thumb_specific
   sub
 
 let run
+    ?(patch_spaces : Patch_info.spaces = [])
     (sub : sub term)
     ~(target : T.target)
     ~(language : T.language)
@@ -117,7 +121,7 @@ let run
   let* sub =
     if is_thumb then begin
       Log.send "%a target detected" T.Language.pp language;
-      thumb_specific sub ~target ~patch_info
+      thumb_specific sub ~target ~patch_info ~patch_spaces
     end else !!sub in
   Log.send "Re-ordering blocks again";
   let sub = Shape.reorder_blks sub in

--- a/vibes-tools/tools/vibes-opt/lib/bir_passes.ml
+++ b/vibes-tools/tools/vibes-opt/lib/bir_passes.ml
@@ -10,6 +10,7 @@ module Hvar = Vibes_higher_vars.Higher_var
 module Subst = Vibes_higher_vars.Substituter
 module Patch_info = Vibes_patch_info.Types
 module Bir_helpers = Vibes_bir.Helpers
+module Spaces = Patch_info.Spaces
 
 open KB.Syntax
 
@@ -64,7 +65,7 @@ let provide_function_info
                   end else !!())))
 
 let thumb_specific
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     (sub : sub term)
     ~(target : T.target)
     ~(patch_info : Patch_info.t) : sub term KB.t =
@@ -80,7 +81,7 @@ let thumb_specific
   sub
 
 let run
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     (sub : sub term)
     ~(target : T.target)
     ~(language : T.language)

--- a/vibes-tools/tools/vibes-opt/lib/bir_passes.mli
+++ b/vibes-tools/tools/vibes-opt/lib/bir_passes.mli
@@ -4,7 +4,7 @@ open Bap_core_theory
 (** [run sub ~target ~language ~patch_info ~func_info ?patch_spaces]
     runs the optimization passes on the subroutine [sub]. *)
 val run :
-  ?patch_spaces:Vibes_patch_info.Types.spaces ->
+  ?patch_spaces:Vibes_patch_info.Types.Spaces.t ->
   sub term ->
   target:Theory.target ->
   language:Theory.language ->

--- a/vibes-tools/tools/vibes-opt/lib/bir_passes.mli
+++ b/vibes-tools/tools/vibes-opt/lib/bir_passes.mli
@@ -1,9 +1,10 @@
 open Bap.Std
 open Bap_core_theory
 
-(** [run sub ~target ~language ~patch_info ~func_info] runs
-    the optimization passes on the subroutine [sub]. *)
+(** [run sub ~target ~language ~patch_info ~func_info ?patch_spaces]
+    runs the optimization passes on the subroutine [sub]. *)
 val run :
+  ?patch_spaces:Vibes_patch_info.Types.spaces ->
   sub term ->
   target:Theory.target ->
   language:Theory.language ->

--- a/vibes-tools/tools/vibes-opt/lib/runner.ml
+++ b/vibes-tools/tools/vibes-opt/lib/runner.ml
@@ -7,13 +7,14 @@ module Log = Vibes_log.Stream
 module Utils = Vibes_utils
 module Serializers = Vibes_serializers
 module Patch_info = Vibes_patch_info.Types
+module Spaces = Patch_info.Spaces
 module Function_info = Vibes_function_info.Types
 module Bir_helpers = Vibes_bir.Helpers
 
 open KB.Syntax
 
 let deserialize_and_opt
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     (sexp : Sexp.t)
     ~(target : T.target)
     ~(language : T.language)
@@ -26,7 +27,7 @@ let deserialize_and_opt
 (* Try to deserialize and optimize the BIR program while
    preserving the toplevel state. *)
 let try_deserialize_and_opt
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     (bir_sexp : Sexp.t)
     ~(target : T.target)
     ~(language : T.language)
@@ -53,8 +54,8 @@ let run
     bir_filepath func_info_filepath bir_outfile;
   let* patch_info = Patch_info.from_file patch_info_filepath in
   let* patch_spaces = match patch_spaces with
-    | Some path -> Patch_info.spaces_from_file path
-    | None -> Ok [] in
+    | Some path -> Spaces.from_file path
+    | None -> Ok Spaces.empty in
   let* target = Utils.Core_theory.get_target target in
   let* language = Utils.Core_theory.get_language language in
   let* raw_bir_code = Utils.Files.get_file_contents_non_empty bir_filepath

--- a/vibes-tools/tools/vibes-opt/lib/runner.ml
+++ b/vibes-tools/tools/vibes-opt/lib/runner.ml
@@ -13,6 +13,7 @@ module Bir_helpers = Vibes_bir.Helpers
 open KB.Syntax
 
 let deserialize_and_opt
+    ?(patch_spaces : Patch_info.spaces = [])
     (sexp : Sexp.t)
     ~(target : T.target)
     ~(language : T.language)
@@ -20,11 +21,12 @@ let deserialize_and_opt
     ~(func_info : Function_info.t) : sub term KB.t =
   let* sub = Serializers.Bir.deserialize sexp in
   Log.send "Deserialized BIR:\n\n%a" Sub.pp sub;
-  Bir_passes.run sub ~target ~language ~patch_info ~func_info
+  Bir_passes.run sub ~target ~language ~patch_info ~patch_spaces ~func_info
 
 (* Try to deserialize and optimize the BIR program while
    preserving the toplevel state. *)
 let try_deserialize_and_opt
+    ?(patch_spaces : Patch_info.spaces = [])
     (bir_sexp : Sexp.t)
     ~(target : T.target)
     ~(language : T.language)
@@ -33,11 +35,12 @@ let try_deserialize_and_opt
   try
     let result = Toplevel.var "vibes-opt" in
     Toplevel.put result @@ deserialize_and_opt bir_sexp
-      ~target ~language ~patch_info ~func_info;
+      ~target ~language ~patch_info ~patch_spaces ~func_info;
     Result.return @@ Toplevel.get result
   with Toplevel.Conflict err -> Error err
 
 let run
+    ?(patch_spaces : string option = None)
     ~(target : string)
     ~(language : string)
     ~(patch_info_filepath : string)
@@ -48,8 +51,10 @@ let run
   Log.send "Vibes_opt.Runner.run '%s' '%s' '%s' '%s' '%s' '%s'"
     target language patch_info_filepath
     bir_filepath func_info_filepath bir_outfile;
-  Log.send "Loading patch-info";
   let* patch_info = Patch_info.from_file patch_info_filepath in
+  let* patch_spaces = match patch_spaces with
+    | Some path -> Patch_info.spaces_from_file path
+    | None -> Ok [] in
   let* target = Utils.Core_theory.get_target target in
   let* language = Utils.Core_theory.get_language language in
   let* raw_bir_code = Utils.Files.get_file_contents_non_empty bir_filepath
@@ -62,9 +67,8 @@ let run
     | [sexp] -> Ok sexp
     | _ -> Error (Errors.Invalid_bir "Expected single S-exp") in
   let* func_info = Function_info.from_file func_info_filepath in
-  Log.send "Function info:\n%a" Function_info.pp func_info;
   let* sub = try_deserialize_and_opt bir_sexp
-      ~target ~language ~patch_info ~func_info in
+      ~target ~language ~patch_info ~patch_spaces ~func_info in
   Log.send "Serializing BIR";
   let bir_sexp = Serializers.Bir.serialize sub in
   let bir_data = Sexp.to_string_hum bir_sexp in

--- a/vibes-tools/tools/vibes-opt/lib/runner.mli
+++ b/vibes-tools/tools/vibes-opt/lib/runner.mli
@@ -2,6 +2,7 @@ open Bap_core_theory
 
 (** Runs the optimizer and serializes the results to [bir_outfile]. *)
 val run :
+  ?patch_spaces:string option ->
   target:string ->
   language:string ->
   patch_info_filepath:string ->

--- a/vibes-tools/tools/vibes-opt/lib/shape.ml
+++ b/vibes-tools/tools/vibes-opt/lib/shape.ml
@@ -5,6 +5,7 @@ open Bap_core_theory
 
 module T = Theory
 module Patch_info = Vibes_patch_info.Types
+module Spaces = Patch_info.Spaces
 module Bir_helpers = Vibes_bir.Helpers
 module Tags = Vibes_bir.Tags
 
@@ -144,10 +145,10 @@ let reorder_blks (sub : sub term) : sub term =
 
 (* Get the maximum address of each patch site. *)
 let collect_conservative_patch_points
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     ~(patch_info : Patch_info.t)
     ~(width : int) : word list =
-  let patch_spaces = match patch_spaces with
+  let patch_spaces = match Spaces.to_list patch_spaces with
     | [] ->
       (* Fall back to the default patch point. *)
       let patch_point =
@@ -183,7 +184,7 @@ let collect_conservative_patch_points
    since it will undo any kind of branch relaxation at the BIR level.
 *)
 let relax_branches
-    ?(patch_spaces : Patch_info.spaces = [])
+    ?(patch_spaces : Spaces.t = Spaces.empty)
     (sub : sub term)
     ~(target : T.target)
     ~(patch_info : Patch_info.t)

--- a/vibes-tools/tools/vibes-opt/lib/shape.ml
+++ b/vibes-tools/tools/vibes-opt/lib/shape.ml
@@ -144,9 +144,10 @@ let reorder_blks (sub : sub term) : sub term =
 
 (* Get the maximum address of each patch site. *)
 let collect_conservative_patch_points
+    ?(patch_spaces : Patch_info.spaces = [])
     ~(patch_info : Patch_info.t)
     ~(width : int) : word list =
-  let patch_spaces = match patch_info.patch_spaces with    
+  let patch_spaces = match patch_spaces with
     | [] ->
       (* Fall back to the default patch point. *)
       let patch_point =
@@ -168,20 +169,21 @@ let collect_conservative_patch_points
 
    Before (assume 0x123456 is too far away):
 
-   bcc 0x123456
-   b continue
+     bcc 0x123456
+     b continue
 
    After:
 
-   bcc relax
-   b continue
+     bcc relax
+     b continue
    relax:
-   b 0x123456
+     b 0x123456
 
    It's important to run this after the edge contraction optimization,
    since it will undo any kind of branch relaxation at the BIR level.
 *)
 let relax_branches
+    ?(patch_spaces : Patch_info.spaces = [])
     (sub : sub term)
     ~(target : T.target)
     ~(patch_info : Patch_info.t)
@@ -189,7 +191,7 @@ let relax_branches
     ~(bwd_limit : int) : sub term KB.t =
   let width = T.Target.code_addr_size target in
   let patch_points =
-    collect_conservative_patch_points ~patch_info ~width in
+    collect_conservative_patch_points ~patch_info ~patch_spaces ~width in
   let fwd_limit = Word.of_int ~width fwd_limit in
   let bwd_limit = Word.of_int ~width bwd_limit in
   let inserted = ref [] in

--- a/vibes-tools/tools/vibes-opt/lib/shape.mli
+++ b/vibes-tools/tools/vibes-opt/lib/shape.mli
@@ -34,7 +34,7 @@ val reorder_blks : sub term -> sub term
     destination is targeted by an unconditional branch.
 *)
 val relax_branches :
-  ?patch_spaces:Vibes_patch_info.Types.spaces ->
+  ?patch_spaces:Vibes_patch_info.Types.Spaces.t ->
   sub term ->
   target:Theory.target ->
   patch_info:Vibes_patch_info.Types.t ->

--- a/vibes-tools/tools/vibes-opt/lib/shape.mli
+++ b/vibes-tools/tools/vibes-opt/lib/shape.mli
@@ -34,6 +34,7 @@ val reorder_blks : sub term -> sub term
     destination is targeted by an unconditional branch.
 *)
 val relax_branches :
+  ?patch_spaces:Vibes_patch_info.Types.spaces ->
   sub term ->
   target:Theory.target ->
   patch_info:Vibes_patch_info.Types.t ->

--- a/vibes-tools/tools/vibes-patch-info/lib/dune
+++ b/vibes-tools/tools/vibes-patch-info/lib/dune
@@ -7,4 +7,5 @@
    vibes-log
    vibes-utils
    vibes-higher-vars)
- (preprocess (pps ppx_yojson_conv ppx_fields_conv)))
+ (preprocess (pps ppx_yojson_conv
+                  ppx_sexp_conv)))

--- a/vibes-tools/tools/vibes-patch-info/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.ml
@@ -1,3 +1,5 @@
+open Bap_core_theory
+
 module Log = Vibes_log.Stream
 module Utils = Vibes_utils
 module Hvar = Vibes_higher_vars.Higher_var
@@ -7,13 +9,24 @@ type space = {
   size : int64 [@key "size"];
 } [@@deriving yojson]
 
+type spaces = space list [@@deriving yojson]
+
+let pp_spaces : Format.formatter -> spaces -> unit =
+  Utils.Json.pp ~yojson_of_t:yojson_of_spaces
+
+let spaces_from_file : string -> (spaces, KB.conflict) result =
+  Utils.Json.from_file
+    ~yojson_of_t:yojson_of_spaces
+    ~t_of_yojson:spaces_of_yojson
+
 type t = {
   patch_point : Utils.Json.Bitvector.t [@key "patch-point"];
   patch_size : int64 [@key "patch-size"];
   sp_align : int [@key "sp-align"];
-  patch_spaces : space list [@default []] [@key "patch-spaces"];
   patch_vars : Hvar.t list [@default []] [@key "patch-vars"];
 } [@@deriving yojson]
 
-let pp = Utils.Json.pp ~yojson_of_t
-let from_file = Utils.Json.from_file ~yojson_of_t ~t_of_yojson
+let pp : Format.formatter -> t -> unit = Utils.Json.pp ~yojson_of_t
+
+let from_file : string -> (t, KB.conflict) result =
+  Utils.Json.from_file ~yojson_of_t ~t_of_yojson

--- a/vibes-tools/tools/vibes-patch-info/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.ml
@@ -1,3 +1,5 @@
+open Core
+open Bap.Std
 open Bap_core_theory
 
 module Log = Vibes_log.Stream
@@ -11,13 +13,79 @@ type space = {
 
 type spaces = space list [@@deriving yojson]
 
-let pp_spaces : Format.formatter -> spaces -> unit =
-  Utils.Json.pp ~yojson_of_t:yojson_of_spaces
+module Spaces = struct
 
-let spaces_from_file : string -> (spaces, KB.conflict) result =
-  Utils.Json.from_file
-    ~yojson_of_t:yojson_of_spaces
-    ~t_of_yojson:spaces_of_yojson
+  module Tree = Interval_tree.Make(struct
+      type t = addr * addr [@@deriving sexp]
+      type point = addr [@@deriving sexp]
+
+      let compare_point : point -> point -> int = Addr.compare
+
+      let compare ((x1, y1) : t) ((x2, y2) : t) : int =
+        match compare_point x1 x2 with
+        | 0 -> compare_point y1 y2
+        | n -> n
+
+      let lower : t -> point = fst
+      let upper : t -> point = snd
+    end)
+
+  type t = unit Tree.t
+
+  let empty : t = Tree.empty
+  let is_empty : t -> bool = Tree.is_empty
+
+  let of_list (l : space list) : t =
+    (* Get an initial widening of spaces that start on the
+       same address. We also convert the size into an end
+       address (being the upper bound on the region). *)
+    let m =
+      List.fold l ~init:Addr.Map.empty ~f:(fun m {address; size} ->
+          if Int64.(size > 0L) then
+            let width = Addr.bitwidth address in
+            let size = Addr.of_int64 size ~width in
+            let end_ = Addr.(pred (address + size)) in
+            Map.update m address ~f:(function
+                | Some e when Addr.(end_ > e) -> end_
+                | Some _ | None -> end_)
+          else m) in
+    Map.fold m ~init:empty ~f:(fun ~key:start ~data:end_ t ->
+        let i = start, end_ in
+        let inters = Tree.intersections t i in
+        if Seq.is_empty inters then Tree.add t i ()
+        else
+          (* For all intervals that intersect with this one, we widen the
+             current interval until it subsumes all of them. *)
+          let t, i =
+            Seq.map inters ~f:fst |>
+            Seq.fold ~init:(t, i) ~f:(fun (t, (x1, y1)) ((x2, y2) as i) ->
+                Tree.remove t i, Addr.(min x1 x2, max y1 y2)) in
+          Tree.add t i ())
+
+  let to_list (t : t) : space list =
+    Tree.to_sequence t |>
+    Seq.map ~f:(fun ((start, end_), ()) ->
+        let size =
+          Bitvec.to_int64 @@
+          Addr.to_bitvec @@
+          Addr.succ @@
+          Addr.(end_ - start) in
+        {address = start; size}) |>
+    Seq.to_list
+
+  let yojson_of_t (t : t) : Yojson.Safe.t =
+    to_list t |> yojson_of_spaces
+
+  let t_of_yojson (j : Yojson.Safe.t) : t =
+    spaces_of_yojson j |> of_list
+
+  let pp : Format.formatter -> t -> unit =
+    Utils.Json.pp ~yojson_of_t
+
+  let from_file : string -> (t, KB.conflict) result =
+    Utils.Json.from_file ~yojson_of_t ~t_of_yojson
+
+end
 
 type t = {
   patch_point : Utils.Json.Bitvector.t [@key "patch-point"];

--- a/vibes-tools/tools/vibes-patch-info/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.mli
@@ -11,6 +11,15 @@ type space = {
   size : int64;
 } [@@deriving yojson]
 
+(** A list of external patch spaces. *)
+type spaces = space list [@@deriving yojson]
+
+(** Pretty-prints the patch spaces. *)
+val pp_spaces : Format.formatter -> spaces -> unit
+
+(** Attempts to deserialize the patch spaces from a JSON file. *)
+val spaces_from_file : string -> (spaces, KB.conflict) result
+
 (** The metadata for a patch.
 
     - [patch_point]: the absolute address of the program
@@ -24,15 +33,12 @@ type space = {
       subtracted from the stack pointer in order to keep
       it aligned when making function calls
 
-    - [patch_spaces]: a list of available external patch sites
-
     - [patch_vars]: higher variable information
 *)
 type t = {
   patch_point : Vibes_utils.Json.Bitvector.t;
   patch_size : int64;
   sp_align : int;
-  patch_spaces : space list;
   patch_vars : Vibes_higher_vars.Higher_var.t list;
 }
 

--- a/vibes-tools/tools/vibes-patch-info/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.mli
@@ -11,14 +11,31 @@ type space = {
   size : int64;
 } [@@deriving yojson]
 
-(** A list of external patch spaces. *)
-type spaces = space list [@@deriving yojson]
+(** A set of patch spaces. *)
+module Spaces : sig
 
-(** Pretty-prints the patch spaces. *)
-val pp_spaces : Format.formatter -> spaces -> unit
+  type t [@@deriving yojson]
 
-(** Attempts to deserialize the patch spaces from a JSON file. *)
-val spaces_from_file : string -> (spaces, KB.conflict) result
+  (** The empty set of spaces. *)
+  val empty : t
+
+  (** Returns [true] if set of spaces is empty. *)
+  val is_empty : t -> bool
+
+  (** Converts a list of spaces into an interval tree where
+      overlapping regions are coalesced. *)
+  val of_list : space list -> t
+
+  (** Returns the interval tree as a list of spaces. *)
+  val to_list : t -> space list
+
+  (** Pretty-prints the patch metadata. *)
+  val pp : Format.formatter -> t -> unit
+
+  (** Attempts to deserialize the metadata from a JSON file. *)
+  val from_file : string -> (t, KB.conflict) result
+
+end
 
 (** The metadata for a patch.
 

--- a/vibes-tools/tools/vibes-patch/bin/main.ml
+++ b/vibes-tools/tools/vibes-patch/bin/main.ml
@@ -22,14 +22,15 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.required arg
 
-  let asm_filepath : string C.Term.t =
-    let info = C.Arg.info ["f"; "asm-filepath"]
-        ~docv:"ASM_FILEPATH"
-        ~doc:"Path to file containing serialized assembly" in
-    let parser = C.Arg.some' C.Arg.file in
-    let default = None in
+  let asm_filepaths : string list C.Term.t =
+    let info = C.Arg.info ["f"; "asm-filepaths"]
+        ~docv:"ASM_FILEPATHS"
+        ~doc:"Path to files containing serialized assembly \
+              (separated by space)" in
+    let parser = C.Arg.list ~sep:' ' C.Arg.file in
+    let default = [] in
     let arg = C.Arg.opt parser default info in
-    C.Arg.required arg
+    C.Arg.non_empty arg
 
   let patched_binary : string C.Term.t =
     let info = C.Arg.info ["o"; "patched-binary"]
@@ -55,9 +56,9 @@ module Cli = struct
       (no_color : bool)
       (target : string)
       (language : string)
-      (patch_info_filepath : string)
+      (patch_spaces : string option)
       (binary : string)
-      (asm_filepath : string)
+      (asm_filepaths : string list)
       (patched_binary : string)
       (ogre_filepath : string option) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
@@ -65,9 +66,9 @@ module Cli = struct
     Runner.run
       ~target
       ~language
-      ~patch_info_filepath
+      ~patch_spaces
       ~binary
-      ~asm_filepath
+      ~asm_filepaths
       ~patched_binary
       ~ogre_filepath |> function
     | Ok () -> Ok ()
@@ -79,9 +80,9 @@ module Cli = struct
       $ Cli_opts.Verbosity.no_color
       $ Cli_opts.Target.target
       $ Cli_opts.Language.language
-      $ Cli_opts.Patch_info.filepath
+      $ Cli_opts.Patch_info.spaces
       $ binary
-      $ asm_filepath
+      $ asm_filepaths
       $ patched_binary
       $ ogre_filepath
     )

--- a/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
@@ -23,9 +23,14 @@ let trampoline (addr : int64) : Asm.block =
   let label = Format.sprintf "trampoline%Ld" addr in
   Asm.Fields_of_block.create ~label ~insns:[b]
 
-let create_trampoline (addr : int64) : Asm.t =
+let create_trampoline
+    (addr : int64)
+    (patch_point : int64)
+    (patch_size : int64) : Asm.t =
   let block = trampoline addr in
-  Asm.{directives = [".syntax unified"]; blocks = [block]}
+  Asm.Fields.create ~patch_point ~patch_size
+    ~directives:[".syntax unified"]
+    ~blocks:[block]
 
 let insert_trampoline (addr : int64) (asm : Asm.t) : Asm.t =
   let block = trampoline addr in

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -192,17 +192,19 @@ let place_patch
 let occupy_space
     (patch : patch)
     (spaces : Patch_info.spaces) : Patch_info.spaces =
-  List.map spaces ~f:(fun space ->
+  List.filter_map spaces ~f:(fun space ->
       let open Int64 in
       let Patch_info.{address; size} = space in
       let width = Word.bitwidth address in
       let address = Bitvec.to_int64 @@ Word.to_bitvec address in
       if patch.addr = address then
         let patch_size = of_int @@ String.length patch.data in
-        let address = Word.of_int64 ~width (address + patch_size) in
         let size = size - patch_size in
-        Patch_info.{address; size}
-      else space)
+        if size > 0L then
+          let address = Word.of_int64 ~width (address + patch_size) in
+          Some Patch_info.{address; size}
+        else None
+      else Some space)
 
 type res = patch list * Patch_info.spaces
 

--- a/vibes-tools/tools/vibes-patch/lib/patcher.mli
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.mli
@@ -7,15 +7,21 @@ type patch = {
   loc : int64;
 }
 
-(** [patch patch_info target language asm ~binary ~patched_binary ~backend]
-    will assemble and place a patch in the original [binary], whose contents
-    are written to the file at path [patched_binary]. *)
+type res = patch list * Vibes_patch_info.Types.spaces
+
+(** [patch target language asms ~binary ~patched_binary ~backend ?spaces] will
+    assemble and place a list of patches in the original [binary], whose contents
+    are written to the file at path [patched_binary].
+
+    The result is the list of patches applied to the binary, as well as the
+    resulting list of external spaces that are now occupied.
+*)
 val patch :
+  ?patch_spaces:Vibes_patch_info.Types.spaces ->
   ?backend:string option ->
-  Vibes_patch_info.Types.t ->
   Theory.target ->
   Theory.language ->
-  Vibes_as.Types.Assembly.t ->
+  Vibes_as.Types.Assembly.t list ->
   binary:string ->
   patched_binary:string ->
-  (patch, KB.conflict) result  
+  (res, KB.conflict) result

--- a/vibes-tools/tools/vibes-patch/lib/patcher.mli
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.mli
@@ -7,7 +7,7 @@ type patch = {
   loc : int64;
 }
 
-type res = patch list * Vibes_patch_info.Types.spaces
+type res = patch list * Vibes_patch_info.Types.Spaces.t
 
 (** [patch target language asms ~binary ~patched_binary ~backend ?spaces] will
     assemble and place a list of patches in the original [binary], whose contents
@@ -17,7 +17,7 @@ type res = patch list * Vibes_patch_info.Types.spaces
     resulting list of external spaces that are now occupied.
 *)
 val patch :
-  ?patch_spaces:Vibes_patch_info.Types.spaces ->
+  ?patch_spaces:Vibes_patch_info.Types.Spaces.t ->
   ?backend:string option ->
   Theory.target ->
   Theory.language ->

--- a/vibes-tools/tools/vibes-patch/lib/runner.ml
+++ b/vibes-tools/tools/vibes-patch/lib/runner.ml
@@ -8,6 +8,7 @@ module Files = Vibes_utils.Files
 module Log = Vibes_log.Stream
 module Asm = Vibes_as.Types.Assembly
 module Patch_info = Vibes_patch_info.Types
+module Spaces = Patch_info.Spaces
 
 let (let*) x f = Result.bind x ~f
 
@@ -52,8 +53,8 @@ let run
   let* target = CT.get_target target in
   let* language = CT.get_language language in
   let* patch_spaces = match patch_spaces with
-    | Some path -> Patch_info.spaces_from_file path
-    | None -> Ok [] in
+    | Some path -> Spaces.from_file path
+    | None -> Ok Spaces.empty in
   let* () = match ogre_filepath with
     | None -> Ok ()
     | Some path -> match Sys_unix.file_exists path with
@@ -66,10 +67,6 @@ let run
     Patcher.patch target language asms
       ~binary ~patched_binary ~patch_spaces
       ~backend:ogre_filepath in
-  begin match spaces with
-    | [] -> ()
-    | _ ->
-      Log.send "Remaining patch spaces:\n%a"
-        Patch_info.pp_spaces spaces;
-  end;
+  if not @@ Spaces.is_empty spaces then
+    Log.send "Remaining patch spaces:\n%a" Spaces.pp spaces;
   Ok ()

--- a/vibes-tools/tools/vibes-patch/lib/runner.ml
+++ b/vibes-tools/tools/vibes-patch/lib/runner.ml
@@ -11,37 +11,49 @@ module Patch_info = Vibes_patch_info.Types
 
 let (let*) x f = Result.bind x ~f
 
+let parse_asms
+    (asm_filepaths : string list) : (Asm.t list, KB.conflict) result =
+  let rec aux acc = function
+    | [] -> Ok (List.rev acc)
+    | path :: rest ->
+      let* asm_sexp_raw = Files.get_file_contents_non_empty path
+          ~error:(fun s ->
+              let msg = Format.sprintf
+                  "Expected non-empty ASM for file %s" s in
+              Errors.Invalid_asm msg) in
+      let* asm_sexps = Sexps.to_sexp asm_sexp_raw
+          ~error:(fun s -> Errors.Invalid_asm (
+              Format.sprintf "Invalid ASM S-exp: %s" s)) in
+      let* asm_sexp = match asm_sexps with
+        | [sexp] -> Ok sexp
+        | _ ->
+          let msg = Format.sprintf "Expected single ASM S-exp" in
+          Error (Errors.Invalid_asm msg) in
+      let* asm = try Ok (Asm.t_of_sexp asm_sexp) with
+        | _ ->
+          let msg = Format.asprintf "Invalid ASM: %a" Sexp.pp_hum asm_sexp in
+          Error (Errors.Invalid_asm msg) in
+      Log.send "Assembly:\n%a\n%!" Asm.pp asm;
+      aux (asm :: acc) rest in
+  aux [] asm_filepaths
+
 let run
+    ?(patch_spaces : string option = None)
     ?(ogre_filepath : string option = None)
     ~(target : string)
     ~(language : string)
-    ~(patch_info_filepath : string)
     ~(binary : string)
-    ~(asm_filepath : string)
+    ~(asm_filepaths : string list)
     ~(patched_binary : string) : (unit, KB.conflict) result =
-  Log.send "Vibes_patch.Runner.run '%s' '%s' '%s' '%s' '%s' '%s'"
-    target language patch_info_filepath binary asm_filepath patched_binary;
+  Log.send "Vibes_patch.Runner.run '%s' '%s' '%s' '%s' '%s'"
+    target language binary
+    (String.concat ~sep:", " asm_filepaths)
+    patched_binary;
   let* target = CT.get_target target in
   let* language = CT.get_language language in
-  let* patch_info = Patch_info.from_file patch_info_filepath in
-  Log.send "Parsed patch info:\n%a\n" Patch_info.pp patch_info;
-  let* asm_sexp_raw = Files.get_file_contents_non_empty asm_filepath
-      ~error:(fun s ->
-          let msg = Format.sprintf "Expected non-empty ASM for file %s" s in
-          Errors.Invalid_asm msg) in
-  let* asm_sexps = Sexps.to_sexp asm_sexp_raw
-      ~error:(fun s -> Errors.Invalid_asm (
-          Format.sprintf "Invalid ASM S-exp: %s" s)) in
-  let* asm_sexp = match asm_sexps with
-    | [sexp] -> Ok sexp
-    | _ ->
-      let msg = Format.sprintf "Expected single ASM S-exp" in
-      Error (Errors.Invalid_asm msg) in
-  let* asm = try Ok (Asm.t_of_sexp asm_sexp) with
-    | _ ->
-      let msg = Format.asprintf "Invalid ASM: %a" Sexp.pp_hum asm_sexp in
-      Error (Errors.Invalid_asm msg) in
-  Log.send "Assembly:\n%a\n%!" Asm.pp asm;
+  let* patch_spaces = match patch_spaces with
+    | Some path -> Patch_info.spaces_from_file path
+    | None -> Ok [] in
   let* () = match ogre_filepath with
     | None -> Ok ()
     | Some path -> match Sys_unix.file_exists path with
@@ -49,9 +61,15 @@ let run
       | `No | `Unknown ->
         let msg = Format.sprintf "OGRE file %s not found" path in
         Error (Errors.Invalid_ogre msg) in
-  let* patch =
-    Patcher.patch patch_info target language
-      asm ~binary ~patched_binary ~backend:ogre_filepath in
-  Format.printf "Placed at 0x%Lx using %d bytes\n%!"
-    patch.Patcher.addr @@ String.length patch.Patcher.data;
+  let* asms = parse_asms asm_filepaths in
+  let* _, spaces =
+    Patcher.patch target language asms
+      ~binary ~patched_binary ~patch_spaces
+      ~backend:ogre_filepath in
+  begin match spaces with
+    | [] -> ()
+    | _ ->
+      Log.send "Remaining patch spaces:\n%a"
+        Patch_info.pp_spaces spaces;
+  end;
   Ok ()

--- a/vibes-tools/tools/vibes-patch/lib/runner.mli
+++ b/vibes-tools/tools/vibes-patch/lib/runner.mli
@@ -2,11 +2,11 @@ open Bap_core_theory
 
 (** Attempts to patch the binary with the provided assembly code. *)
 val run :
+  ?patch_spaces:string option ->
   ?ogre_filepath:string option ->
   target:string ->
   language:string ->
-  patch_info_filepath:string ->
   binary:string ->
-  asm_filepath:string ->
+  asm_filepaths:string list ->
   patched_binary:string ->
   (unit, KB.conflict) result

--- a/vibes-tools/tools/vibes-patch/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch/lib/types.ml
@@ -19,7 +19,7 @@ module type Target = sig
     to_addr:(int64 -> int64) ->
     Asm.t
 
-  val create_trampoline : int64 -> Asm.t
+  val create_trampoline : int64 -> int64 -> int64 -> Asm.t
   val has_inline_data : Asm.t -> bool
   val adjusted_org : int64 -> int64 option
 

--- a/vibes-tools/tools/vibes-patch/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch/lib/types.mli
@@ -27,9 +27,9 @@ module type Target = sig
     to_addr:(int64 -> int64) ->
     Asm.t
 
-  (** [create_trampoline addr] creates a fresh assembly program for the
-      purpose of jumping to the address [addr]. *)
-  val create_trampoline : int64 -> Asm.t
+  (** [create_trampoline addr patch_point patch_size] creates a fresh
+      assembly program for the purpose of jumping to the address [addr]. *)
+  val create_trampoline : int64 -> int64 -> int64 -> Asm.t
 
   (** Returns [true] if the assembly program is expected to
       have inline data when assembled. *)


### PR DESCRIPTION
This re-introduces the functionality from the monolithic tool for applying multiple patches in one go, as well as providing extra constraints for MiniZinc.

For extra constraints, it works the same as before, no surprises here.

For multiple patches, we change the setup of the `patch-info` config file. Specifically, we separate the list of external patch spaces to its own file, since it can be re-used by multiple patches. Next, we will provide the `patch-info` file to `vibes-as`, where we transfer the `patch-site` and `patch-size` fields to the resulting assembly file. Finally, `vibes-patch` can now take in a list of assembly files, each of which are telling the patcher where they want to be placed, and iteratively we can chomp away at the external patch spaces if they exist. After that, we can return not only the applied patches but also the modified spaces (since they are now occupied). Right now we just print them out if `--verbose` is enabled, but we could output them to a file in the future if we want.