### PR TITLE
Preserve overwritten instructions if the user tells us to

### DIFF
--- a/vibes-tools/tools/vibes-as/lib/arm/arm_printer.ml
+++ b/vibes-tools/tools/vibes-as/lib/arm/arm_printer.ml
@@ -161,6 +161,6 @@ let ir ~(is_thumb : bool) : Asm.printer = fun t patch_info ->
     List.map ~f:(block ~is_thumb) t.blks |>
     Result.all in
   let directives = [".syntax unified"] in
-  let Patch_info.{patch_point; patch_size; _} = patch_info in
+  let Patch_info.{patch_point; patch_size; overwrite; _} = patch_info in
   let patch_point = Bitvec.to_int64 @@ Word.to_bitvec patch_point in
-  Asm.Fields.create ~patch_point ~patch_size ~directives ~blocks
+  Asm.Fields.create ~patch_point ~patch_size ~overwrite ~directives ~blocks

--- a/vibes-tools/tools/vibes-as/lib/types.ml
+++ b/vibes-tools/tools/vibes-as/lib/types.ml
@@ -11,6 +11,7 @@ module Assembly = struct
   type t = {
     patch_point : int64;
     patch_size : int64;
+    overwrite : bool;
     directives : string list;
     blocks : block list;
   } [@@deriving fields, sexp]

--- a/vibes-tools/tools/vibes-as/lib/types.mli
+++ b/vibes-tools/tools/vibes-as/lib/types.mli
@@ -13,6 +13,7 @@ module Assembly : sig
   type t = {
     patch_point : int64;
     patch_size : int64;
+    overwrite : bool;
     directives : string list;
     blocks : block list;
   } [@@deriving fields, sexp]

--- a/vibes-tools/tools/vibes-init/lib/types.ml
+++ b/vibes-tools/tools/vibes-init/lib/types.ml
@@ -93,7 +93,8 @@ let pp_makefile (ppf : Format.formatter) (t : t) : unit =
       Format.fprintf ppf "parse%d:\n%!" i;
       Format.fprintf ppf "\trm -f $(PATCH_%d_BIR)\n%!" i;
       Format.fprintf ppf "\t$(MAKE) $(PATCH_%d_BIR)\n\n%!" i;
-      Format.fprintf ppf "$(PATCH_%d_BIR):\n%!" i;
+      Format.fprintf ppf "$(PATCH_%d_BIR): \
+                          $(PATCH_%d) $(PATCH_%d_INFO)\n%!" i i i;
       Format.fprintf ppf "\tvibes-parse \
                           --target $(TARGET) \
                           --patch-filepath $(PATCH_%d) \

--- a/vibes-tools/tools/vibes-init/lib/types.ml
+++ b/vibes-tools/tools/vibes-init/lib/types.ml
@@ -218,6 +218,7 @@ let dummy_patch_info : Patch_info.t = {
     patch_point = Addr.of_string "0x1234:32";
     patch_size = 4L;
     sp_align = 0;
+    overwrite = true;
     patch_vars = [];
   }
 

--- a/vibes-tools/tools/vibes-patch-info/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.ml
@@ -85,6 +85,7 @@ type t = {
   patch_point : Utils.Json.Bitvector.t [@key "patch-point"];
   patch_size : int64 [@key "patch-size"];
   sp_align : int [@key "sp-align"];
+  overwrite : bool [@default true] [@key "overwrite"];
   patch_vars : Hvar.t list [@default []] [@key "patch-vars"];
 } [@@deriving yojson]
 

--- a/vibes-tools/tools/vibes-patch-info/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.mli
@@ -49,12 +49,16 @@ end
       subtracted from the stack pointer in order to keep
       it aligned when making function calls
 
+    - [overwrite]: the patch is allowed to overwrite existing
+      code at the patch point.
+
     - [patch_vars]: higher variable information
 *)
 type t = {
   patch_point : Vibes_utils.Json.Bitvector.t;
   patch_size : int64;
   sp_align : int;
+  overwrite : bool;
   patch_vars : Vibes_higher_vars.Higher_var.t list;
 }
 

--- a/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
@@ -53,6 +53,12 @@ let has_ldr_large_const : Asm.t -> bool =
 let has_inline_data (asm : Asm.t) : bool =
   has_ldr_large_const asm
 
+let ends_in_jump (asm : Asm.t) : bool = match List.last asm.blocks with
+  | None -> false
+  | Some block -> match List.last block.insns with
+    | None -> false
+    | Some insn -> String.is_prefix insn ~prefix:"b "
+
 let adjusted_org (loc : int64) : int64 option =
   match Int64.rem loc 4L with
   | 0L -> None

--- a/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
@@ -28,12 +28,20 @@ let create_trampoline
     (patch_point : int64)
     (patch_size : int64) : Asm.t =
   let block = trampoline addr in
-  Asm.Fields.create ~patch_point ~patch_size
+  Asm.Fields.create ~patch_point ~patch_size ~overwrite:true
     ~directives:[".syntax unified"]
     ~blocks:[block]
 
 let insert_trampoline (addr : int64) (asm : Asm.t) : Asm.t =
   let block = trampoline addr in
+  Asm.{asm with blocks = asm.blocks @ [block]}
+
+let insert_overwritten
+    (addr : int64)
+    (asm : Asm.t)
+    (insns : string list) : Asm.t =
+  let label = Format.sprintf "overwritten%Ld" addr in
+  let block = Asm.Fields_of_block.create ~label ~insns in
   Asm.{asm with blocks = asm.blocks @ [block]}
 
 let has_ldr_large_const : Asm.t -> bool =
@@ -53,6 +61,7 @@ let adjusted_org (loc : int64) : int64 option =
 let situate
     ?(org : int64 option = None)
     ?(jmp : int64 option = None)
+    ?(overwritten : string list = [])
     (asm : Asm.t)
     ~(loc : int64)
     ~(to_addr : int64 -> int64) : Asm.t =
@@ -70,6 +79,10 @@ let situate
     let label = Constants.patch_start_label in
     let start = Asm.Fields_of_block.create ~label ~insns:[] in
     Asm.{asm with blocks = start :: asm.blocks} in
+  let asm =
+    if not asm.Asm.overwrite then
+      insert_overwritten (to_addr loc) asm overwritten
+    else asm in
   match jmp with
   | Some jmp -> insert_trampoline jmp asm
   | None -> asm

--- a/vibes-tools/tools/vibes-patch/lib/errors.ml
+++ b/vibes-tools/tools/vibes-patch/lib/errors.ml
@@ -5,8 +5,11 @@ type KB.conflict +=
   | Invalid_binary of string
   | Invalid_address of string
   | Invalid_ogre of string
+  | Invalid_insn of string
+  | Invalid_size of string
   | Unsupported_target of string
   | No_patch_spaces of string
+  | No_disasm of string
 
 let printer (e : KB.conflict) : string option =
   match e with
@@ -14,8 +17,11 @@ let printer (e : KB.conflict) : string option =
   | Invalid_binary s -> Some s
   | Invalid_address s -> Some s
   | Invalid_ogre s -> Some s
+  | Invalid_insn s -> Some s
+  | Invalid_size s -> Some s
   | Unsupported_target s -> Some s
   | No_patch_spaces s -> Some s
+  | No_disasm s -> Some s
   | _ -> None
 
 let () = KB.Conflict.register_printer printer

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -289,10 +289,13 @@ let patch
   let rec apply spaces acc = function
     | [] -> Ok (List.rev acc, spaces)
     | asm :: asms ->
+      let point = asm.Asm.patch_point in
       let* overwritten =
-        overwritten dis target
-          asm.Asm.patch_point
-          asm.Asm.patch_size mem in
+        overwritten dis target point asm.Asm.patch_size mem in
+      if not @@ List.is_empty overwritten then
+        Log.send "The following instructions will be \
+                  overwritten at 0x%Lx:\n%s\n"
+          point @@ String.concat overwritten ~sep:"\n";
       let* patch, trampoline =
         place_patch spaces spec asm info language overwritten in
       Log.send "Solved patch placement: %a" pp_patch patch;

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -104,10 +104,12 @@ let try_patch_site
     (* For patching at the original location, we need to insert
        a jump to the end of the specified space. We need to check
        that the patch still fits because inserting a jump will
-       increase the length of the patch. *)
+       increase the length of the patch. However, if the patch
+       already ends in a jump then we'll just discard the leftover
+       space since we're redirecting control flow somewhere else. *)
     let* data = try_ @@ match ret with
-      | None -> assert false
-      | Some _ -> ret in
+      | None when not (Target.ends_in_jump asm) -> assert false
+      | None | Some _ -> ret in
     Result.return begin match of_int @@ String.length data with
       | len when len <= size -> Some {data; addr; loc}
       | len ->

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -262,7 +262,7 @@ let overwritten
       Error (Errors.Invalid_insn msg)
     | Ok (_, None, _) ->
       (* The bytes at this address failed to decode to a valid instruction,
-         but we should just assume that it's free space (i.e. inline data).
+         but we should just assume that it's free space (i.e. inline data)
          and that the user intends to overwrite this region. *)
       Ok (List.rev acc)
     | Ok (m, Some insn, next) ->

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -261,9 +261,10 @@ let overwritten
       let msg = Format.asprintf "Disasm error: %a" Error.pp err in
       Error (Errors.Invalid_insn msg)
     | Ok (_, None, _) ->
-      let a = Memory.min_addr mem in
-      let msg = Format.asprintf "Invalid instruction at %a" Word.pp a in
-      Error (Errors.Invalid_insn msg)
+      (* The bytes at this address failed to decode to a valid instruction,
+         but we should just assume that it's free space (i.e. inline data).
+         and that the user intends to overwrite this region. *)
+      Ok (List.rev acc)
     | Ok (m, Some insn, next) ->
       let len = Memory.length m in
       let n = n - len and t = t + len in

--- a/vibes-tools/tools/vibes-patch/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch/lib/types.ml
@@ -22,6 +22,7 @@ module type Target = sig
 
   val create_trampoline : int64 -> int64 -> int64 -> Asm.t
   val has_inline_data : Asm.t -> bool
+  val ends_in_jump : Asm.t -> bool
   val adjusted_org : int64 -> int64 option
 
   module Toolchain : Toolchain

--- a/vibes-tools/tools/vibes-patch/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch/lib/types.ml
@@ -14,6 +14,7 @@ module type Target = sig
   val situate :
     ?org:int64 option ->
     ?jmp:int64 option ->
+    ?overwritten:string list ->
     Asm.t ->
     loc:int64 ->
     to_addr:(int64 -> int64) ->

--- a/vibes-tools/tools/vibes-patch/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch/lib/types.mli
@@ -18,10 +18,13 @@ module type Target = sig
 
   (** [situate asm ~loc ?jmp] will situate the patch program [asm] at the
       location [loc]. [jmp] is the location to jump to at the end of the
-      program. *)
+      program. [overwritten] is the list of assembly instructions that were
+      overwritten, and shall be included in the patch code if [asm] cannot
+      erase these instructions. *)
   val situate :
     ?org:int64 option ->
     ?jmp:int64 option ->
+    ?overwritten:string list ->
     Asm.t ->
     loc:int64 ->
     to_addr:(int64 -> int64) ->

--- a/vibes-tools/tools/vibes-patch/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch/lib/types.mli
@@ -38,10 +38,14 @@ module type Target = sig
       have inline data when assembled. *)
   val has_inline_data : Asm.t -> bool
 
+  (** Returns [true] if the assembly program ends in an unconditional
+      jump. *)
+  val ends_in_jump : Asm.t -> bool
+
   (** Returns the adjusted origin of the patch based on the patch
       location. *)
   val adjusted_org : int64 -> int64 option
-  
+
   (** The toolchain for the target. *)
   module Toolchain : Toolchain
 


### PR DESCRIPTION
Some patches require us to only insert new code, which means we will have to overwrite some instructions that are needed by the program.

The user can tell us this with the `overwrite` field in the patch info config file. If it's `false` (default `true`) then any instructions that would be overwritten should be inserted at the end of the patch code.

We don't do any analysis on the function being patched, so it's up to the user to specify the necessary constraints (such as in the patch vars) on what registers and so on are needed by such instructions.