### PR TITLE
Adjust model + add some code for optional copy instructions

### DIFF
--- a/resources/minizinc/model.mzn
+++ b/resources/minizinc/model.mzn
@@ -120,7 +120,7 @@ constraint forall(o in operation_t where card(operation_opcodes[o]) > 0 )(
 % operand should only be assigned to temporary it either defines or uses.
 % Is this implicit from other constraints?
 constraint forall(o in operand_t)(
-        temp[o] in { t | t in temp_t where definer[t] = o \/ o in users[t] }
+  temp[o] in {t | t in temp_t where definer[t] == o \/ o in users[t]}
 );
 
 
@@ -144,7 +144,7 @@ constraint forall(t in temp_t)(
 % use minizinc built-in diffn.
 % The original unison model uses many different options
 function array[int] of var int : block_array(array[temp_t] of var int : a, block_t : b) =
-    [a[t] | t in temp_t where temp_block[t] = b ];
+    [a[t] | t in temp_t where temp_block[t] == b];
 
 % [diffn_nonstrict]  https://www.minizinc.org/doc-latest/en/lib-globals.html#packing-constraints
 % Constrains rectangles i , given by their origins ( x [ i ], y [ i ]) and
@@ -154,9 +154,9 @@ function array[int] of var int : block_array(array[temp_t] of var int : a, block
 constraint forall(blk in block_t)(
         diffn(block_array(reg,blk),  % built in global minizinc constraint
               block_array(start_cycle,blk),
-            %  block_array([width[t] * bool2int(live[t]) | t in temp_t ], b), % no this is bad
-            block_array(width, blk),
-              [end_cycle[t] - start_cycle[t] | t in temp_t where temp_block[t] = blk])
+              block_array([width[t] * bool2int(live[t]) | t in temp_t], blk), % no this is bad
+            %block_array(width, blk),
+              [end_cycle[t] - start_cycle[t] | t in temp_t where temp_block[t] == blk])
 );
 
 
@@ -170,29 +170,21 @@ constraint forall(p in operand_t) (
 % C3.2. register class constraint
 constraint forall(p in operand_t where active[operand_operation[p]])(
     reg[temp[p]] in class_t[p, opcode[operand_operation[p]]]
-
 );
 
 % C4 Every operation that is not a copy must be active.
-constraint forall(o in operation_t where not (o in copy))(
-    active[o]
-);
+constraint forall(o in operation_t where not (o in copy))(active[o]);
 
-% C5.1  A temporary is live if its defining operation is active
-constraint forall(t in temp_t)(
-    live[t] = active[operand_operation[definer[t]]]
-);
+predicate active_definer(temp_t: t) = active[operand_operation[definer[t]]];
 
-% C5.2 For an active operation there must be at least one live temporary available
-constraint forall(t in temp_t)(
-    %card({p | p in users[t] where live[t] == active[operand_operation[p]] /\ temp[p] == t}) >= 1 % fishy encoding
-    live[t] <- exists(p in users[t])( active[operand_operation[p]] /\ temp[p] = t ) % should be both way implication?
-);
+predicate active_users(temp_t: t) =
+ exists(p in users[t])(active[operand_operation[p]] /\ temp[p] == t);
+
+% C5 For a live temporary t, the definer of t and at least one user of t must be active
+constraint forall(t in temp_t)(live[t] <-> (active_definer(t) /\ active_users(t)));
 
 % C6 Congruent temps map to the same register
-constraint forall (p in temp_t, q in temp_t where q in congruent[p])(
-    reg[p] = reg[q]
-);
+constraint forall(p in temp_t, q in temp_t where q in congruent[p])(reg[p] = reg[q]);
 
 %% Instruction Scheduling Constraints
 
@@ -234,12 +226,9 @@ constraint forall (t in temp_t)(
 
 %C10 Then end cycle of a temporary is the last issue cycle of operations that use it.
 constraint forall (t in temp_t where card(users[t]) > 0 /\ live[t])(
-
-   end_cycle[t] == max(
-      % [ start[t] + 10 ] ++  % a kludge to make minizinc not upset when users[t] is empty.
-       [ issue[operand_operation[p]]  | p in users[t] where temp[p] == t  ]  )
-       % shouldn't this also be contingent on whether the user is active?
-       % I suppose the temporary won't be live then.
+  end_cycle[t] == max([issue[operand_operation[p]] | p in users[t] where temp[p] == t])
+    % shouldn't this also be contingent on whether the user is active?
+    % I suppose the temporary won't be live then.
 );
 
 % In blocks must be at start of block
@@ -276,8 +265,8 @@ predicate exclude_reg(reg_t: r) =
 %-------------------------------
 
 % Minimize number of registers
-solve minimize card( {r | p in operand_t, r in reg_t where reg[temp[p]] = r } );
-
+%solve minimize card({r | p in operand_t, r in reg_t where reg[temp[p]] == r});
+solve minimize card({r | t in temp_t, r in reg_t where r == reg[t]});
 
 %TODO. For the moment, mere satisfaction would make me happy
 % minimize max( [end[t] | t in temp_t ] ) % total estimated time (spilling is slow)

--- a/resources/minizinc/model.mzn
+++ b/resources/minizinc/model.mzn
@@ -143,7 +143,7 @@ constraint forall(t in temp_t)(
 % use cumulative?
 % use minizinc built-in diffn.
 % The original unison model uses many different options
-function array[int] of var int : block_array(array[temp_t] of var int : a, block_t : b) =
+function array[int] of var int : block_arr(array[temp_t] of var int : a, block_t : b) =
     [a[t] | t in temp_t where temp_block[t] == b];
 
 % [diffn_nonstrict]  https://www.minizinc.org/doc-latest/en/lib-globals.html#packing-constraints
@@ -152,11 +152,10 @@ function array[int] of var int : block_array(array[temp_t] of var int : a, block
 
 % still need to include live[t] condition
 constraint forall(blk in block_t)(
-        diffn(block_array(reg,blk),  % built in global minizinc constraint
-              block_array(start_cycle,blk),
-              block_array([width[t] * bool2int(live[t]) | t in temp_t], blk), % no this is bad
-            %block_array(width, blk),
-              [end_cycle[t] - start_cycle[t] | t in temp_t where temp_block[t] == blk])
+  diffn(block_arr(reg,blk),  % built in global minizinc constraint
+        block_arr(start_cycle,blk),
+        block_arr([width[t] * bool2int(live[t]) | t in temp_t], blk),
+        [end_cycle[t] - start_cycle[t] | t in temp_t where temp_block[t] == blk])
 );
 
 
@@ -191,27 +190,19 @@ constraint forall(p in temp_t, q in temp_t where q in congruent[p])(reg[p] = reg
 % C7.1  The issue cycle of operations that define temporaries must be before all
 %       active operations that use that temporary
 constraint forall (t in temp_t)(
-     let {operand_t : p = definer[t]} in
-        forall(q in users[t] where active[operand_operation[q]] /\ temp[q] == t)(
-            issue[operand_operation[q]] >= issue[operand_operation[p]] + latency[opcode[operand_operation[p]]]
-    )
+  let {operand_t : p = definer[t]} in
+  forall(q in users[t] where active[operand_operation[q]] /\ temp[q] == t)(
+    let {operation_t : u = operand_operation[q]} in
+    let {operation_t : d = operand_operation[p]} in
+    issue[u] >= issue[d] + latency[opcode[d]]
+  )
 );
-
-% resource consumptions contraint
-% TODO. We are not tracking resource consumption yet
-/*
-use cumulative
-
-constraint forall (b in block_ts)(
-    forall (s in Resource)
-)
-*/
 
 %% Integration Constraints
 
 % C9 The start cycle of a temporary is the issue cycle of it's defining operation
 constraint forall (t in temp_t where live[t])(
-   start_cycle[t] == issue[operand_operation[definer[t]]]
+   start_cycle[t] = issue[operand_operation[definer[t]]]
 );
 
 % Not in paper. Do we want this?
@@ -226,7 +217,7 @@ constraint forall (t in temp_t)(
 
 %C10 Then end cycle of a temporary is the last issue cycle of operations that use it.
 constraint forall (t in temp_t where card(users[t]) > 0 /\ live[t])(
-  end_cycle[t] == max([issue[operand_operation[p]] | p in users[t] where temp[p] == t])
+  end_cycle[t] = max([issue[operand_operation[p]] | p in users[t] where temp[p] == t])
     % shouldn't this also be contingent on whether the user is active?
     % I suppose the temporary won't be live then.
 );
@@ -235,7 +226,7 @@ constraint forall (t in temp_t where card(users[t]) > 0 /\ live[t])(
 % Outs must be at end
 
 constraint forall (blk in block_t)(
-    issue[block_ins[blk]] == 0
+    issue[block_ins[blk]] = 0
     /\
     % worse but possibly faster
     % issue[block_outs[blk]] == MAXC

--- a/resources/minizinc/model.mzn
+++ b/resources/minizinc/model.mzn
@@ -226,7 +226,7 @@ constraint forall (t in temp_t where card(users[t]) > 0 /\ live[t])(
 % Outs must be at end
 
 constraint forall (blk in block_t)(
-    issue[block_ins[blk]] = 0
+    issue[block_ins[blk]] == 0
     /\
     % worse but possibly faster
     % issue[block_outs[blk]] == MAXC

--- a/vibes-tools/resources/patch.2.asm
+++ b/vibes-tools/resources/patch.2.asm
@@ -1,4 +1,5 @@
-((patch_point 66560) (patch_size 2) (directives (".syntax unified"))
+((patch_point 66560) (patch_size 2) (overwrite true)
+ (directives (".syntax unified"))
  (blocks
   (((label blk0000001b)
     (insns

--- a/vibes-tools/resources/patch.asm
+++ b/vibes-tools/resources/patch.asm
@@ -1,4 +1,5 @@
-((patch_point 66560) (patch_size 2) (directives (".syntax unified"))
+((patch_point 66560) (patch_size 2) (overwrite true)
+ (directives (".syntax unified"))
  (blocks
   (((label blk00000019)
-    (insns ("movw R9, #48879" "mov R8, #3" "str R8, [R9]"))))))
+    (insns ("movw R9, #48879" "mov R3, #3" "str R3, [R9]"))))))

--- a/vibes-tools/tools/vibes-as/lib/arm/arm_printer.ml
+++ b/vibes-tools/tools/vibes-as/lib/arm/arm_printer.ml
@@ -88,7 +88,7 @@ let mk_loc_list
   match op with
   | "ldr" when len = 2 && is_const (List.nth_exn args 1) ->
     Ok [Neither; Neither]
-  | "ldr" | "ldrh" | "ldrb" | "str" ->
+  | "ldr" | "ldrh" | "ldrb" | "str" | "strh" | "strb" ->
     if      len = 2 then Ok [Neither; Both]
     else if len = 3 then Ok [Neither; Open; Close]
     else if len = 4 then Ok [Neither; Open; Neither; Close]

--- a/vibes-tools/tools/vibes-ir/lib/types.ml
+++ b/vibes-tools/tools/vibes-ir/lib/types.ml
@@ -398,7 +398,8 @@ let users_map (t : t) : Opvar.t list Var.Map.t =
   List.fold t.blks ~init:Var.Map.empty ~f:(fun acc blk ->
       Block.users_map blk |> Map.merge acc ~f:(fun ~key:_ -> function
           | `Left a | `Right a -> Some a
-          | `Both (a, b) -> Some (a @ b)))
+          | `Both (a, b) ->
+            Some (Utils.dedup_list_stable (a @ b) ~compare:Opvar.compare)))
 
 let temp_to_block (t : t) : tid Var.Map.t =
   List.concat_map t.blks ~f:(fun blk ->

--- a/vibes-tools/tools/vibes-minizinc/lib/errors.ml
+++ b/vibes-tools/tools/vibes-minizinc/lib/errors.ml
@@ -3,12 +3,14 @@ open Bap_core_theory
 type KB.conflict +=
   | Deserialization_failed of string
   | Unsupported_role of string
+  | Unsupported_target of string
   | Invalid_width of string
 
 let printer (e : KB.conflict) : string option =
   match e with
   | Deserialization_failed s -> Some s
   | Unsupported_role s -> Some s
+  | Unsupported_target s -> Some s
   | Invalid_width s -> Some s
   | _ -> None
 

--- a/vibes-tools/tools/vibes-select/lib/arm/arm_ops.ml
+++ b/vibes-tools/tools/vibes-select/lib/arm/arm_ops.ml
@@ -81,6 +81,8 @@ let ldr : Ir.opcode = op "ldr"
 let ldrh : Ir.opcode = op "ldrh"
 let ldrb : Ir.opcode = op "ldrb"
 let str : Ir.opcode = op "str"
+let strh : Ir.opcode = op "strh"
+let strb : Ir.opcode = op "strb"
 let cmp : Ir.opcode = op "cmp"
 
 let b ?(cnd : Cond.t option = None) () : Ir.opcode =

--- a/vibes-tools/tools/vibes-select/lib/arm/arm_ops.mli
+++ b/vibes-tools/tools/vibes-select/lib/arm/arm_ops.mli
@@ -30,6 +30,8 @@ val ldr : opcode
 val ldrh : opcode
 val ldrb : opcode
 val str : opcode
+val strh : opcode
+val strb : opcode
 val cmp : opcode
 val b : ?cnd:cond option -> unit -> opcode
 val bl : ?cnd:cond option -> unit -> opcode


### PR DESCRIPTION
Currently we don't generate optional copy instructions and in fact we do this optimization prematurely in the instruction selector, but we could make room for it in the future.

Additionally, I made some adjustments to the MiniZinc model that seems to produce better results.