### PR TITLE
Various bugfixes

### DIFF
--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -848,7 +848,8 @@ module Main = struct
                   | Some t ->
                     return (t, Exp.with_type e1 t, Exp.with_type e2 t)
                 end
-            end          | _ -> typ_unify_error e t1 t2 in
+            end
+          | _ -> typ_unify_error e t1 t2 in
         BINARY (b, e1, e2, t)
 
   end

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -1133,16 +1133,29 @@ module Main = struct
       let t1 = Exp.typeof e1 in
       let* spre2, e2, spost2 = exp rhs in
       let t2 = Exp.typeof e2 in
-      match Type.unify t1 t2 with
-      | None -> typ_unify_error Cabs.(BINARY (b, lhs, rhs)) t1 t2
-      | Some VOID ->
+      let* t, e1, e2 =
+        let default () = match Type.unify t1 t2 with
+          | None -> typ_unify_error Cabs.(BINARY (b, lhs, rhs)) t1 t2
+          | Some t -> return (t, Exp.with_type e1 t, Exp.with_type e2 t) in
+        match t1, t2 with
+        | INT _, INT _ -> begin
+            (* The size of a constant integer is ambiguous until
+               we use it in some kind of operation. *)
+            match e1, e2 with
+            | CONST_INT _, _ -> return (t2, Exp.with_type e1 t2, e2)
+            | _, CONST_INT _ -> return (t1, e1, Exp.with_type e2 t1)
+            | _ -> default ()
+          end
+        | _ -> default () in
+      match t with
+      | VOID ->
         let msg = if no_ptr then "Expected integral type"
           else "Expected integral or pointer type" in
         typ_error Cabs.(BINARY (b, lhs, rhs)) VOID msg
-      | Some ((PTR _) as t) when no_ptr ->
+      | (PTR _) as t when no_ptr ->
         typ_error Cabs.(BINARY (b, lhs, rhs)) t
           "Pointer type is not allowed"
-      | Some t ->
+      | _ ->
         let e1 = Exp.with_type e1 t in
         let e2 = Exp.with_type e2 t in
         let f op e1 e2 t = return @@ BINARY (op, e1, e2, t) in

--- a/vibes-tools/tools/vibes-init/bin/main.ml
+++ b/vibes-tools/tools/vibes-init/bin/main.ml
@@ -32,16 +32,6 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.value arg
 
-  let ogre_filepath : string option C.Term.t =
-    let info = C.Arg.info ["O"; "ogre"]
-        ~docv:"OGRE"
-        ~doc:"Path/name of the optional OGRE loader file. It must \
-              be an absolute filepath, e.g. ./myloader.ogre" in
-    let parser = C.Arg.some' C.Arg.string in
-    let default = None in
-    let arg = C.Arg.opt parser default info in
-    C.Arg.value arg
-
   let binary : string C.Term.t =
     let info = C.Arg.info ["i"; "binary"]
         ~docv:"BINARY"
@@ -67,7 +57,6 @@ module Cli = struct
       (language : string)
       (model_filepath : string)
       (patch_names : string list)
-      (ogre_filepath : string option)
       (binary : string)
       (patched_binary : string) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
@@ -77,7 +66,6 @@ module Cli = struct
       ~language
       ~patch_names
       ~model_filepath
-      ~ogre_filepath
       ~binary
       ~patched_binary
       () |> function
@@ -92,7 +80,6 @@ module Cli = struct
       $ Cli_opts.Language.language
       $ model_filepath
       $ patch_names
-      $ ogre_filepath
       $ binary
       $ patched_binary
     )

--- a/vibes-tools/tools/vibes-init/lib/runner.ml
+++ b/vibes-tools/tools/vibes-init/lib/runner.ml
@@ -11,15 +11,7 @@ module Inputs = Vibes_constants.Inputs
 
 let (let*) x f = Result.bind x ~f
 
-let collect_ogre (binary : string) : (string, KB.conflict) result =
-  Log.send "Generating OGRE file %s for binary %s" Inputs.default_ogre binary;
-  let* image = Vibes_patch.Loader.image binary in
-  let data = Format.asprintf "%a" Ogre.Doc.pp @@ Image.spec image in
-  let* () = Files.write_or_error data Inputs.default_ogre in
-  Ok Inputs.default_ogre
-
 let run
-    ?(ogre_filepath : string option = None)
     ~(target : string)
     ~(language : string)
     ~(patch_names : string list)
@@ -27,19 +19,14 @@ let run
     ~(binary : string)
     ~(patched_binary : string)
     () : (unit, KB.conflict) result =
-  Log.send "Vibes_init.Runner.run '%s' '%s' '%s' '%s' '%s' '%s' '%s'"
+  Log.send "Vibes_init.Runner.run '%s' '%s' '%s' '%s' '%s' '%s'"
     target language (String.concat patch_names ~sep:", ")
-    model_filepath binary patched_binary
-    (Option.value ogre_filepath ~default:Inputs.default_ogre);
+    model_filepath binary patched_binary;
   let* target = CT.get_target target in    
   let* language = CT.get_language language in
-  let* ogre = match ogre_filepath with
-    | None -> collect_ogre binary
-    | Some ogre -> Ok ogre in
-  let t =
-    Types.create target language ~patch_names
+  let t = Types.create target language ~patch_names
       ~model:model_filepath ~binary ~patched_binary
-      ~ogre ~spaces:Inputs.default_patch_spaces in
+      ~spaces:Inputs.default_patch_spaces in
   Log.send "Generating template files";
   let* () = Types.generate_files t in
   Log.send "Generating Makefile";

--- a/vibes-tools/tools/vibes-init/lib/types.ml
+++ b/vibes-tools/tools/vibes-init/lib/types.ml
@@ -28,7 +28,6 @@ type t = {
   model : string;
   binary : string;
   patched_binary : string;
-  ogre : string;
   patches : patch list;
   spaces : string;
 }
@@ -52,14 +51,12 @@ let create
     ~(model : string)
     ~(binary : string)
     ~(patched_binary : string)
-    ~(ogre : string)
     ~(spaces : string) : t = {
   target;
   language;
   model;
   binary;
   patched_binary;
-  ogre;
   spaces;
   patches = List.map patch_names ~f:create_patch;
 }
@@ -73,7 +70,6 @@ let pp_makefile (ppf : Format.formatter) (t : t) : unit =
   Format.fprintf ppf "BINARY := %s\n%!" t.binary;
   Format.fprintf ppf "PATCHED_BINARY := %s\n%!" t.patched_binary;
   Format.fprintf ppf "SPACES := %s\n%!" t.spaces;
-  Format.fprintf ppf "OGRE := %s\n\n%!" t.ogre;
   (* Patch definitions. *)
   List.iteri t.patches ~f:(fun i p ->
       Format.fprintf ppf "# Definitions for patch %s (%d)\n\n%!" p.name i;
@@ -201,7 +197,6 @@ let pp_makefile (ppf : Format.formatter) (t : t) : unit =
                       --patch-spaces $(SPACES) \
                       --asm-filepaths %s \
                       --patched-binary $(PATCHED_BINARY) \
-                      --ogre $(OGRE) \
                       --verbose\n%!" asms;
   Format.fprintf ppf "\tchmod +x $(PATCHED_BINARY)\n\n%!";
   (* clean *)

--- a/vibes-tools/tools/vibes-init/lib/types.mli
+++ b/vibes-tools/tools/vibes-init/lib/types.mli
@@ -20,7 +20,6 @@ type t = {
   model : string;
   binary : string;
   patched_binary : string;
-  ogre : string;
   patches : patch list;
   spaces : string;
 }
@@ -33,7 +32,6 @@ val create :
   model:string ->
   binary:string ->
   patched_binary:string ->
-  ogre:string ->
   spaces:string ->
   t
 

--- a/vibes-tools/tools/vibes-patch/bin/main.ml
+++ b/vibes-tools/tools/vibes-patch/bin/main.ml
@@ -41,16 +41,6 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.required arg
 
-  let ogre_filepath : string option C.Term.t =
-    let info = C.Arg.info ["O"; "ogre"]
-        ~docv:"OGRE"
-        ~doc:"Path/name of the optional OGRE loader file. It must \
-              be an absolute filepath, e.g. ./myloader.ogre" in
-    let parser = C.Arg.some' C.Arg.string in
-    let default = None in
-    let arg = C.Arg.opt parser default info in
-    C.Arg.value arg
-
   let run
       (verbose : bool)
       (no_color : bool)
@@ -59,8 +49,7 @@ module Cli = struct
       (patch_spaces : string option)
       (binary : string)
       (asm_filepaths : string list)
-      (patched_binary : string)
-      (ogre_filepath : string option) : (unit, string) result =
+      (patched_binary : string) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
     Log.send "Running 'vibes-as'";
     Runner.run
@@ -70,7 +59,6 @@ module Cli = struct
       ~binary
       ~asm_filepaths
       ~patched_binary
-      ~ogre_filepath
       () |> function
     | Ok () -> Ok ()
     | Error e -> Error (KB.Conflict.to_string e)
@@ -85,7 +73,6 @@ module Cli = struct
       $ binary
       $ asm_filepaths
       $ patched_binary
-      $ ogre_filepath
     )
 
   let cmd = C.Cmd.v info runner

--- a/vibes-tools/tools/vibes-patch/lib/loader.ml
+++ b/vibes-tools/tools/vibes-patch/lib/loader.ml
@@ -2,10 +2,8 @@ open Core
 open Bap.Std
 open Bap_core_theory
 
-let image
-    ?(backend : string = "llvm")
-    (filepath : string) : (image, KB.conflict) result =
-  match Image.create filepath ~backend with
+let image (filepath : string) : (image, KB.conflict) result =
+  match Image.create filepath ~backend:"llvm" with
   | Ok (image, _) -> Ok image
   | Error err ->
     let msg = Format.asprintf "Error loading %s: %a" filepath Error.pp err in

--- a/vibes-tools/tools/vibes-patch/lib/loader.mli
+++ b/vibes-tools/tools/vibes-patch/lib/loader.mli
@@ -1,6 +1,5 @@
 open Bap.Std
 open Bap_core_theory
 
-(** [image filepath ?backend] attemps to load the raw binary at
-    [filepath]. An optional loader [backend] can be provided. *)
-val image : ?backend:string -> string -> (image, KB.conflict) result
+(** [image filepath] attemps to load the raw binary at [filepath]. *)
+val image : string -> (image, KB.conflict) result

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -282,14 +282,13 @@ let overwritten
 
 let patch
     ?(patch_spaces : Spaces.t = Spaces.empty)
-    ?(backend : string option = None)
     (target : T.target)
     (language : T.language)
     (asms : Asm.t list)
     ~(binary : string)
     ~(patched_binary : string) : (res, KB.conflict) result =
   Log.send "Loading binary %s" binary;
-  let* image = Loader.image binary ?backend in
+  let* image = Loader.image binary in
   let memmap = Image.memory image in
   let spec = Image.spec image in
   let* dis, info = target_info target language in

--- a/vibes-tools/tools/vibes-patch/lib/patcher.mli
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.mli
@@ -18,7 +18,6 @@ type res = patch list * Vibes_patch_info.Types.Spaces.t
 *)
 val patch :
   ?patch_spaces:Vibes_patch_info.Types.Spaces.t ->
-  ?backend:string option ->
   Theory.target ->
   Theory.language ->
   Vibes_as.Types.Assembly.t list ->

--- a/vibes-tools/tools/vibes-patch/lib/runner.ml
+++ b/vibes-tools/tools/vibes-patch/lib/runner.ml
@@ -40,7 +40,6 @@ let parse_asms
 
 let run
     ?(patch_spaces : string option = None)
-    ?(ogre_filepath : string option = None)
     ~(target : string)
     ~(language : string)
     ~(binary : string)
@@ -56,18 +55,9 @@ let run
   let* patch_spaces = match patch_spaces with
     | Some path -> Spaces.from_file path
     | None -> Ok Spaces.empty in
-  let* () = match ogre_filepath with
-    | None -> Ok ()
-    | Some path -> match Sys_unix.file_exists path with
-      | `Yes -> Ok ()
-      | `No | `Unknown ->
-        let msg = Format.sprintf "OGRE file %s not found" path in
-        Error (Errors.Invalid_ogre msg) in
   let* asms = parse_asms asm_filepaths in
-  let* _, spaces =
-    Patcher.patch target language asms
-      ~binary ~patched_binary ~patch_spaces
-      ~backend:ogre_filepath in
+  let* _, spaces = Patcher.patch target language asms
+      ~binary ~patched_binary ~patch_spaces in
   if not @@ Spaces.is_empty spaces then
     Log.send "Remaining patch spaces:\n%a" Spaces.pp spaces;
   Ok ()

--- a/vibes-tools/tools/vibes-patch/lib/runner.mli
+++ b/vibes-tools/tools/vibes-patch/lib/runner.mli
@@ -3,7 +3,6 @@ open Bap_core_theory
 (** Attempts to patch the binary with the provided assembly code. *)
 val run :
   ?patch_spaces:string option ->
-  ?ogre_filepath:string option ->
   target:string ->
   language:string ->
   binary:string ->

--- a/vibes-tools/tools/vibes-patch/lib/utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/utils.ml
@@ -7,15 +7,22 @@ type region = {
   offset : int64;
 }
 
+(* Search for the largest code region containing the address. *)
 let find_code_region
     (loc : int64)
     (spec : Ogre.doc) : region option =
-  Ogre.require ~that:(fun (addr, size, _) ->
-      Int64.(addr <= loc && loc <= addr + size))
-    Image.Scheme.code_region |>
-  Fn.flip Ogre.eval spec |> function
-  | Ok (addr, size, offset) -> Some {addr; size; offset}
-  | Error _ -> None
+  let compare (_, s1, _) (_, s2, _) = Int64.compare s2 s1 in
+  Ogre.foreach Ogre.Query.(begin
+      let open Image.Scheme in
+      let addr = code_region.(addr) in
+      let size = code_region.(size) in
+      select ~where:(addr <= int loc && int loc < addr + size)
+        (from code_region)
+    end) ~f:Fn.id |> Fn.flip Ogre.eval spec |> Or_error.ok |>
+  Option.map ~f:Seq.to_list |>
+  Option.map ~f:(List.sort ~compare) |>
+  Option.bind ~f:List.hd |>
+  Option.map ~f:(fun (addr, size, offset) -> {addr; size; offset})
 
 let addr_to_offset (addr : int64) (region : region) : int64 =
   Int64.(addr - region.addr + region.offset)


### PR DESCRIPTION
1. Querying code regions for a particular address in `vibes-patch` could result in multiple matches, so we should instead collect all of them and pick the largest one.
2. We shouldn't ask for OGRE files in the tools, since the only real use we have for them is during verification (i.e. when we actually disassemble and lift a binary). None of the current VIBES tools do this (only CBAT does).
3. Fixed an issue in Patch C frontend where with certain binary operators, we need to coerce the type of one of the operands if it is a constant integer (this was already done for other arithmetic operators).