### PR TITLE
Infer the target and language from the binary in `vibes-init`

### DIFF
--- a/vibes-tools/docs/tutorial/Tutorial.md
+++ b/vibes-tools/docs/tutorial/Tutorial.md
@@ -106,8 +106,6 @@ vibes-init \
   --patch-names=my-patch \
   --binary=main.exe \
   --patched-binary=main.patched.exe \
-  --target=bap:armv7+le \
-  --language=bap:llvm-armv7 \
   --verbose
 ```
 

--- a/vibes-tools/tools/vibes-as/lib/solver.ml
+++ b/vibes-tools/tools/vibes-as/lib/solver.ml
@@ -2,6 +2,7 @@ open Core
 open Bap_core_theory
 
 module T = Theory
+module CT = Vibes_utils.Core_theory
 module Log = Vibes_log.Stream
 module Ir = Vibes_ir.Types
 module Params = Vibes_minizinc.Types.Params
@@ -15,7 +16,7 @@ let opt
     (ir : Ir.t)
     (target : T.target) : (Ir.t, KB.conflict) result =
   let+ is_nop, unconditional_branch_target =
-    if T.Target.belongs Arm_target.parent target then
+    if CT.is_arm32 target then
       let open Arm_utils in
       Ok (is_nop, unconditional_branch_target)
     else

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -4,6 +4,7 @@ open Bap_c.Std
 open Monads.Std
 open Bap_core_theory
 
+module CT = Vibes_utils.Core_theory
 module Utils = C_utils
 module Log = Vibes_log.Stream
 module Hvar = Vibes_higher_vars.Higher_var
@@ -1636,10 +1637,8 @@ let data_of_tgt (target : Theory.target) : Data_model.t KB.t =
   let fail () =
     fail @@ Format.asprintf "Unsupported target %a"
       Theory.Target.pp target in
-  if Theory.Target.belongs Arm_target.parent target then
-    if Theory.Target.bits target = 32
-    then KB.return Data_model.{sizes = `ILP32; schar = false}
-    else fail ()
+  if CT.is_arm32 target then
+    KB.return Data_model.{sizes = `ILP32; schar = false}
   else fail ()
 
 (* Translate a definition. *)

--- a/vibes-tools/tools/vibes-common-cli-options/lib/language.ml
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/language.ml
@@ -3,8 +3,19 @@ module C = Cmdliner
 let language : string C.Term.t =
   let info = C.Arg.info ["l"; "language"]
     ~docv:"LANGUAGE"
-    ~doc:"Name of language (e.g., \"llvm-armv7\", etc.)" in
+    ~doc:"Name of language (e.g., \"llvm-armv7\", \
+          \"llvm-thumb\", etc.)" in
   let parser = C.Arg.some' C.Arg.string in
   let default = None in
   let arg = C.Arg.opt parser default info in
   C.Arg.required arg
+
+let language_optional : string option C.Term.t =
+  let info = C.Arg.info ["l"; "language"]
+    ~docv:"LANGUAGE"
+    ~doc:"Optional name of language (e.g., \
+          \"llvm-armv7\", \"llvm-thumb\", etc.)" in
+  let parser = C.Arg.some' C.Arg.string in
+  let default = None in
+  let arg = C.Arg.opt parser default info in
+  C.Arg.value arg

--- a/vibes-tools/tools/vibes-common-cli-options/lib/language.mli
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/language.mli
@@ -1,2 +1,5 @@
 (** The [Theory.language] name. *)
 val language : string Cmdliner.Term.t
+
+(** The optional [Theory.language] name. *)
+val language_optional : string option Cmdliner.Term.t

--- a/vibes-tools/tools/vibes-init/bin/main.ml
+++ b/vibes-tools/tools/vibes-init/bin/main.ml
@@ -53,8 +53,7 @@ module Cli = struct
   let run
       (verbose : bool)
       (no_color : bool)
-      (target : string)
-      (language : string)
+      (language : string option)
       (model_filepath : string)
       (patch_names : string list)
       (binary : string)
@@ -62,7 +61,6 @@ module Cli = struct
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
     Log.send "Running 'vibes-parse'";
     Runner.run
-      ~target
       ~language
       ~patch_names
       ~model_filepath
@@ -76,8 +74,7 @@ module Cli = struct
       const run
       $ Cli_opts.Verbosity.verbose
       $ Cli_opts.Verbosity.no_color
-      $ Cli_opts.Target.target
-      $ Cli_opts.Language.language
+      $ Cli_opts.Language.language_optional
       $ model_filepath
       $ patch_names
       $ binary

--- a/vibes-tools/tools/vibes-init/lib/errors.ml
+++ b/vibes-tools/tools/vibes-init/lib/errors.ml
@@ -1,0 +1,15 @@
+open Bap_core_theory
+
+type KB.conflict +=
+  | Unsupported_target of string
+  | No_entry_point of string
+  | Invalid_target_lang of string
+
+let printer (e : KB.conflict) : string option =
+  match e with
+  | Unsupported_target s -> Some s
+  | No_entry_point s -> Some s
+  | Invalid_target_lang s -> Some s
+  | _ -> None
+
+let () = KB.Conflict.register_printer printer

--- a/vibes-tools/tools/vibes-init/lib/runner.mli
+++ b/vibes-tools/tools/vibes-init/lib/runner.mli
@@ -3,8 +3,7 @@ open Bap_core_theory
 (** Runs the VIBES initializer; generates a Makefile for the project as
     well as empty/template files. *)
 val run :
-  target:string ->
-  language:string ->
+  ?language:string option ->
   patch_names:string list ->
   model_filepath:string ->
   binary:string ->

--- a/vibes-tools/tools/vibes-init/lib/types.mli
+++ b/vibes-tools/tools/vibes-init/lib/types.mli
@@ -26,14 +26,13 @@ type t = {
 
 (** Creates the information for generating the patch build process. *)
 val create :
-  Theory.target ->
-  Theory.language ->
+  ?language:Theory.language option ->
   patch_names:string list ->
   model:string ->
   binary:string ->
   patched_binary:string ->
   spaces:string ->
-  t
+  (t, KB.conflict) result
 
 (** Pretty-prints the Makefile for running the pipeline. *)
 val pp_makefile : Format.formatter -> t -> unit

--- a/vibes-tools/tools/vibes-patch/lib/errors.ml
+++ b/vibes-tools/tools/vibes-patch/lib/errors.ml
@@ -2,7 +2,6 @@ open Bap_core_theory
 
 type KB.conflict +=
   | Invalid_asm of string
-  | Invalid_binary of string
   | Invalid_address of string
   | Invalid_ogre of string
   | Invalid_insn of string
@@ -14,7 +13,6 @@ type KB.conflict +=
 let printer (e : KB.conflict) : string option =
   match e with
   | Invalid_asm s -> Some s
-  | Invalid_binary s -> Some s
   | Invalid_address s -> Some s
   | Invalid_ogre s -> Some s
   | Invalid_insn s -> Some s

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -3,6 +3,7 @@ open Bap.Std
 open Bap_core_theory
 
 module T = Theory
+module CT = Vibes_utils.Core_theory
 module Constants = Vibes_constants.Asm
 module Patch_info = Vibes_patch_info.Types
 module Spaces = Patch_info.Spaces
@@ -20,7 +21,7 @@ let target_info
     (target : T.target)
     (language : T.language) : (dis * target, KB.conflict) result =
   let* info =
-    if T.Target.belongs Arm_target.parent target then
+    if CT.is_arm32 target then
       Ok (module Arm_utils : Types.Target)
     else
       let msg = Format.asprintf "Unsupported target %a" T.Target.pp target in
@@ -288,7 +289,7 @@ let patch
     ~(binary : string)
     ~(patched_binary : string) : (res, KB.conflict) result =
   Log.send "Loading binary %s" binary;
-  let* image = Loader.image binary in
+  let* image = Vibes_utils.Loader.image binary in
   let memmap = Image.memory image in
   let spec = Image.spec image in
   let* dis, info = target_info target language in

--- a/vibes-tools/tools/vibes-select/lib/selector.ml
+++ b/vibes-tools/tools/vibes-select/lib/selector.ml
@@ -5,6 +5,7 @@ open Bap_core_theory
 module T = Theory
 module Log = Vibes_log.Stream
 module Utils = Vibes_utils
+module CT = Utils.Core_theory
 module Tags = Vibes_bir.Tags
 module Ir = Vibes_ir.Types
 module Linear = Vibes_linear_ssa.Linearizer
@@ -21,8 +22,8 @@ let run
   let* sub = Linear.transform sub ~hvars in
   Log.send "Linearized BIR:\n%a" Sub.pp sub;
   let* select, preassign =
-    if T.Target.belongs Arm_target.parent target then
-      let is_thumb = Utils.Core_theory.is_thumb language in
+    if CT.is_arm32 target then
+      let is_thumb = CT.is_thumb language in
       !!(Arm_selector.select ~is_thumb, Arm_utils.preassign ~is_thumb)
     else
       let msg = Format.asprintf

--- a/vibes-tools/tools/vibes-utils/lib/core_theory.ml
+++ b/vibes-tools/tools/vibes-utils/lib/core_theory.ml
@@ -4,8 +4,11 @@ open Bap_core_theory
 module T = Theory
 
 let is_thumb (language : T.language) : bool = 
-  String.is_substring ~substring:"thumb" @@
-  T.Language.to_string language
+  T.Language.(language = Arm_target.llvm_t32)
+
+let is_arm32 (target : T.target) : bool =
+  T.Target.belongs Arm_target.parent target &&
+  T.Target.bits target = 32
 
 let get_target (name : string) : (T.target, KB.conflict) result =
   match T.Target.lookup name with

--- a/vibes-tools/tools/vibes-utils/lib/core_theory.mli
+++ b/vibes-tools/tools/vibes-utils/lib/core_theory.mli
@@ -3,6 +3,9 @@ open Bap_core_theory
 (** Returns [true] if the language is Thumb. *)
 val is_thumb : Theory.language -> bool
 
+(** Returns [true] if the target is 32-bit ARM. *)
+val is_arm32 : Theory.target -> bool
+
 (** [get_target name] returns the target with the name [name],
     if it exists. *)
 val get_target : string -> (Theory.target, KB.conflict) result

--- a/vibes-tools/tools/vibes-utils/lib/dune
+++ b/vibes-tools/tools/vibes-utils/lib/dune
@@ -4,6 +4,8 @@
  (libraries
    findlib.dynload
    bap
+   bap-arm
+   bap-core-theory
    core
    yojson
    ppx_yojson_conv_lib

--- a/vibes-tools/tools/vibes-utils/lib/errors.ml
+++ b/vibes-tools/tools/vibes-utils/lib/errors.ml
@@ -10,6 +10,7 @@ type KB.conflict +=
    | Json_deserialization_error of string
    | Unknown_target of string
    | Unknown_language of string
+   | Invalid_binary of string
 
 let printer (e : KB.conflict) : string option =
   match e with
@@ -22,6 +23,7 @@ let printer (e : KB.conflict) : string option =
   | Json_deserialization_error s -> Some s
   | Unknown_target s -> Some s
   | Unknown_language s -> Some s
+  | Invalid_binary s -> Some s
   | _ -> None
 
 let () = KB.Conflict.register_printer printer

--- a/vibes-tools/tools/vibes-utils/lib/loader.ml
+++ b/vibes-tools/tools/vibes-utils/lib/loader.ml
@@ -2,8 +2,10 @@ open Core
 open Bap.Std
 open Bap_core_theory
 
-let image (filepath : string) : (image, KB.conflict) result =
-  match Image.create filepath ~backend:"llvm" with
+let image
+    ?(backend : string = "llvm")
+    (filepath : string) : (image, KB.conflict) result =
+  match Image.create filepath ~backend with
   | Ok (image, _) -> Ok image
   | Error err ->
     let msg = Format.asprintf "Error loading %s: %a" filepath Error.pp err in

--- a/vibes-tools/tools/vibes-utils/lib/loader.mli
+++ b/vibes-tools/tools/vibes-utils/lib/loader.mli
@@ -2,4 +2,4 @@ open Bap.Std
 open Bap_core_theory
 
 (** [image filepath] attemps to load the raw binary at [filepath]. *)
-val image : string -> (image, KB.conflict) result
+val image : ?backend:string -> string -> (image, KB.conflict) result


### PR DESCRIPTION
The user can still provide the language if our heuristic gets it wrong. Also fixes checks for `Arm_target.parent`, since we should also check if it's 32-bit ARM (we don't support 64-bit ARM).

Additionally, the MiniZinc backend shouldn't be considering floating point registers right now, which should cut down on solving time.