### PR TITLE
Try extending the ELF code segment in `vibes-patch`

### DIFF
--- a/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/arm/arm_utils.ml
@@ -10,8 +10,10 @@ module Filename = Stdlib.Filename
 
 let (let*) x f = Result.bind x ~f
 
-let assembler = "/usr/bin/arm-linux-gnueabi-as"
-let objcopy = "/usr/bin/arm-linux-gnueabi-objcopy"
+let assembler : string = "/usr/bin/arm-linux-gnueabi-as"
+let objcopy : string = "/usr/bin/arm-linux-gnueabi-objcopy"
+
+let max_insn_length : int = 4
 
 let trampoline (addr : int64) : Asm.block =
   let op = Ops.b () in

--- a/vibes-tools/tools/vibes-patch/lib/dune
+++ b/vibes-tools/tools/vibes-patch/lib/dune
@@ -5,6 +5,7 @@
  (public_name vibes-patch)
  (libraries
    bap
+   bap-elf
    bap-core-theory
    str
    vibes-log

--- a/vibes-tools/tools/vibes-patch/lib/errors.ml
+++ b/vibes-tools/tools/vibes-patch/lib/errors.ml
@@ -6,9 +6,11 @@ type KB.conflict +=
   | Invalid_ogre of string
   | Invalid_insn of string
   | Invalid_size of string
+  | Invalid_binary of string
   | Unsupported_target of string
   | No_patch_spaces of string
   | No_disasm of string
+  | No_code_segment of string
 
 let printer (e : KB.conflict) : string option =
   match e with
@@ -17,9 +19,11 @@ let printer (e : KB.conflict) : string option =
   | Invalid_ogre s -> Some s
   | Invalid_insn s -> Some s
   | Invalid_size s -> Some s
+  | Invalid_binary s -> Some s
   | Unsupported_target s -> Some s
   | No_patch_spaces s -> Some s
   | No_disasm s -> Some s
+  | No_code_segment s -> Some s
   | _ -> None
 
 let () = KB.Conflict.register_printer printer

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -310,10 +310,18 @@ let try_patch_site
               available, %Ld bytes needed)" addr size len;
     Ok None
 
+(* The available space after the code segment won't be marked by BAP
+   as a valid code region, so we will pretend it exists.
+
+   We look for code regions in the OGRE doc under the assumption that
+   not all mapped regions will be code (or even executable), therefore
+   if the user tried to place a patch in a non-code region we would
+   end up with a broken binary.
+*)
 let extern_region (info : info) (addr : int64) : Utils.region option =
   let open Int64 in
   if addr >= info.code.end_
-  && addr  < info.code.end_ + info.code.room then Some Utils.{
+  && addr < info.code.end_ + info.code.room then Some Utils.{
       addr = info.code.end_;
       size = info.code.room;
       offset = info.code.off + info.code.size;

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -359,12 +359,11 @@ let rec try_patch_spaces
           (* Bytes required for the trampoline. *)
           let len = of_int @@ String.length trampoline.data in
           Log.send "Trampoline fits (%Ld bytes)" len;
-          (* Bytes that will be replaced by the trampoline. *)
-          let osize = len - size in
           (* If the trampoline is bigger than the number of bytes
              we intended to replace, then we need to disassemble
              the remaining instructions that would have been
              overwritten. *)
+          let osize = len - size in
           if osize > 0L then
             (* Start at the end of the instructions that we intended
                to overwrite. *)
@@ -372,7 +371,7 @@ let rec try_patch_spaces
             Log.send "%Ld bytes remain, need to disassemble at 0x%Lx"
               osize oaddr;
             overwritten info.o Target.target oaddr osize
-          else Ok ([], len) in
+          else Ok ([], size) in
         let* patch =
           try_patch_site info region jumpto
             space.size (Some (addr + n))

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -185,8 +185,8 @@ module Elf = struct
     let rd64be pos = Bigstring.get_int64_t_be data ~pos in
     let wr32le pos v = Bigstring.set_int32_t_le data ~pos @@ to_int32_trunc v in
     let wr32be pos v = Bigstring.set_int32_t_be data ~pos @@ to_int32_trunc v in
-    let wr64le pos v = Bigstring.set_int64_t_le data ~pos v in
-    let wr64be pos v = Bigstring.set_int64_t_be data ~pos v in
+    let wr64le pos = Bigstring.set_int64_t_le data ~pos in
+    let wr64be pos = Bigstring.set_int64_t_be data ~pos in
     let rd16, rd, wr, fs, ms, ps, po = match elf.e_class, elf.e_data with
       | ELFCLASS32, ELFDATA2LSB -> rd16le, rd32le, wr32le, 16L, 20L, 42, 28
       | ELFCLASS32, ELFDATA2MSB -> rd16be, rd32be, wr32be, 16L, 20L, 42, 28
@@ -197,7 +197,7 @@ module Elf = struct
     let phentsize, phoff = rd16 ps, rd po in
     let entry = phoff + of_int i * phentsize in
     wr (to_int_exn (entry + fs)) (seg.p_filesz + size);
-    wr (to_int_exn (entry + ms)) (seg.p_memsz + size)
+    wr (to_int_exn (entry + ms)) (seg.p_memsz  + size)
 
   let is_pt_load (seg : segment) : bool = match seg.p_type with
     | PT_LOAD -> true

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -394,6 +394,7 @@ let place_patch
     (info : info)
     (patch_spaces : spaces)
     (asm : Asm.t) : (patch * patch option, KB.conflict) result =
+  let open Int64 in
   let module Target = (val info.target) in
   let addr, size = asm.patch_point, asm.patch_size in
   Log.send "Attempting patch point 0x%Lx with %Ld bytes of space" addr size;
@@ -407,9 +408,8 @@ let place_patch
   Log.send "Found region (addr=0x%Lx, size=%Ld, offset=0x%Lx)"
     region.addr region.size region.offset;
   let* patch =
-    if Int64.(size > 0L) then
-      let ret = Int64.(addr + size) in
-      try_patch_site info region addr size (Some ret) asm []
+    if size > 0L then
+      try_patch_site info region addr size (Some (addr + size)) asm []
     else begin
       Log.send "Patch size is zero, need external patch space";
       Ok None

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -208,7 +208,7 @@ let is_pf_exec (seg : Elf.segment) : bool =
 
 let find_elf_segment
     (elf : Elf.t)
-    (addr : int64) : (Elf.segment * int, KB.conflict) result =
+    (addr : int64) : (elf_seg, KB.conflict) result =
   Seq.find_mapi elf.e_segments ~f:(fun i seg ->
       if Int64.(seg.p_vaddr = addr)
       && is_pt_load seg && is_pf_exec seg

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -449,18 +449,16 @@ let consume_space (patch : patch) (spaces : spaces) : spaces =
         else None
       else Some space)
 
+type asms = Asm.t list
 type res = patch list * Spaces.t
-type batch = patch list * spaces * Asm.t list
+type batch = patch list * spaces * asms
 
 let rec place_and_consume
     ?(acc : patch list = [])
     (info : info)
-    (spaces : spaces)
-    (asms : Asm.t list) : (batch, KB.conflict) result =
-  match asms with
+    (spaces : spaces) : asms -> (batch, KB.conflict) result = function
   | [] -> Ok (List.rev acc, spaces, [])
-  | (asm : Asm.t) :: rest ->
-    match place_patch info spaces asm with
+  | ((asm : Asm.t) :: rest) as asms -> match place_patch info spaces asm with
     | Error (Errors.No_patch_spaces _) ->
       Ok (List.rev acc, spaces, asms)
     | Error _ as err -> err

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -333,13 +333,14 @@ let extern_region (info : info) (addr : int64) : Utils.region option =
 let collect_overwritten
     (info : info)
     (patch : patch)
+    (patch_name : string)
     (addr : int64)
     (size : int64) : (string list * int64, KB.conflict) result =
   let open Int64 in
   let module Target = (val info.target) in
   (* Bytes required for the patch. *)
   let len = of_int @@ String.length patch.data in
-  Log.send "Trampoline fits (%Ld bytes)" len;
+  Log.send "%s fits (%Ld bytes)" patch_name len;
   (* If the patch is bigger than the number of bytes
      we intended to replace, then we need to disassemble
      the remaining instructions that would have been
@@ -389,7 +390,8 @@ let rec try_patch_spaces
         Log.send "Trampoline doesn't fit";
         next ()
       | Some trampoline ->
-        let* overwritten, n = collect_overwritten info trampoline addr size in
+        let* overwritten, n =
+          collect_overwritten info trampoline "Trampoline" addr size in
         let* patch =
           try_patch_site info region jumpto
             space.size (Some (addr + n))

--- a/vibes-tools/tools/vibes-patch/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch/lib/types.ml
@@ -24,6 +24,7 @@ module type Target_utils = sig
   val has_inline_data : Asm.t -> bool
   val ends_in_jump : Asm.t -> bool
   val adjusted_org : int64 -> int64 option
+  val max_insn_length : int
 
   module Toolchain : Toolchain
 

--- a/vibes-tools/tools/vibes-patch/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch/lib/types.mli
@@ -45,6 +45,9 @@ module type Target_utils = sig
       location. *)
   val adjusted_org : int64 -> int64 option
 
+  (** The maximum number of bytes that an instruction can occupy. *)
+  val max_insn_length : int
+
   (** The toolchain for the target. *)
   module Toolchain : Toolchain
 

--- a/vibes-tools/tools/vibes-patch/lib/utils.mli
+++ b/vibes-tools/tools/vibes-patch/lib/utils.mli
@@ -9,6 +9,10 @@ type region = {
     contains [addr]. *)
 val find_code_region : int64 -> Ogre.doc -> region option
 
+(** [find_mapped_region addr spec] looks up the mapped region in [spec] that
+    contains [addr]. *)
+val find_mapped_region : int64 -> Ogre.doc -> region option
+
 (** Converts a virtual address into a file offset. Assumes that the address
     is contained within the region. *)
 val addr_to_offset : int64 -> region -> int64


### PR DESCRIPTION
As an alternative to the user-provided external patch spaces, it turns out that we can do a minimally-invasive edit to the program header entry of the main code segment, i.e. simply extending its size.  The inspiration came from this Binary Ninja plugin I found: https://github.com/jeffli678/bnhook/blob/master/hookmanager.py#L76

I've observed that there is a decent amount of space between the end of the code segment and the next segment that gets loaded into memory (usually the data segment). The biggest surprise to me is that this technique actually works for how simple it is.

