### PR TITLE
More fixes

### DIFF
--- a/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.ml
@@ -1,25 +1,44 @@
 open Core
 
+let dummy_decl : string = "void dummy()"
+let dummy_len : int = String.length dummy_decl + 1
+
+let file_pos (input : string) (lexbuf : Lexing.lexbuf) : string =
+  let open Lexing in
+  let pos = lexbuf.lex_curr_p in
+  let l, c =
+    (* The lexer seems to ignore the newlines when updating the
+       position in the buffer, so we will do it manually. *)
+    let c = pos.pos_cnum - pos.pos_bol + 1 in
+    let init = 1, 1, c and finish (l, c, _) = l, c in
+    String.fold_until input ~init ~finish ~f:(fun (l, c, r) x ->
+        let l, c, r = match x with
+          | '\r' -> l, 1, r
+          | '\n' -> l + 1, 1, r
+          | _ -> l, c + 1, r - 1 in
+        if r <= 1 then Stop (l, c)
+        else Continue (l, c, r)) in
+  (* First line should account for the dummy declaration. *)
+  let c = if l = 1 then c - dummy_len else c in
+  Format.sprintf "line %d, column %d" l c
+
 (* Parses a string into a Cabs.file *)
 let parse_c_file (input : string) : (Cabs.file, string) result =
-  let open Clexer in
-  try
-    init_lexicon ();
-    Ok (Cparser.file initial @@ Lexing.from_string input)
-  with
-  | Parsing.Parse_error -> Error "Parsing.Parse_error"
-  | Cabs.BadType -> Error "Cabs.BadType"
-  | Cabs.BadModifier -> Error "Cabs.BadModifier"
-  | Invalid_argument _ ->
-    (* Workaround due to a FrontC bug *)
-    Error "Some FrontC parse error"
-  | _ -> Error "Internal parse error."
+  let lexbuf = Lexing.from_string input ~with_positions:true in
+  Clexer.init_lexicon ();
+  match Cparser.file Clexer.initial lexbuf with
+  | exception exn ->
+    let msg =
+      Format.asprintf "%a: %s" Exn.pp exn @@
+      file_pos input lexbuf in
+    Error msg
+  | ast -> Ok ast
 
 (* Parses a sequence of C statements (a body) by wrapping it in a
    dummy function, parsing that as a file and then extracting the
    first def from the result *)
 let parse (input : string) : (Cabs.definition, string) result =
-  let p = Printf.sprintf "int VIBES_PATCH_WRAPPER_FUN(){\n%s\n}" input in
+  let p = Printf.sprintf "%s{%s}" dummy_decl input in
   match parse_c_file p with
   | Ok [def] -> Ok def
   | Ok [] -> Error "No definitions parsed"


### PR DESCRIPTION
1. Allow empty C file as input to `vibes-parse`
2. Show line and column numbers when the C parser fails
3. Fix case in branch relaxation where there is no patch spaces and the patch size is 0. Our solution to this problem is still hacky and I don't like it.