### PR TITLE
Have `vibes-patch` output the modified OGRE file

### DIFF
--- a/vibes-tools/resources/binja/patcheditor.py
+++ b/vibes-tools/resources/binja/patcheditor.py
@@ -183,11 +183,6 @@ class PatchEditor(QDialog):
       with open(filename(name, "c"), "w") as f:
         f.write(c)
 
-    ogre = self.ogre.ogre
-    if ogre.functions:
-      with open(filename("loader", "ogre"), "w") as f:
-        f.write(str(ogre))
-
     with open(filename("patch-spaces", "json"), "w") as f:
       spaces = db.get_spaces(self.data)
       s = patchspaces.serialize(self.data, spaces)
@@ -198,13 +193,22 @@ class PatchEditor(QDialog):
     for name in self.patches.keys():
       names.append(name)
 
-    print("Running vibes-init in", savedir)
-    proc = subprocess.run([
+    args = [
       "vibes-init",
       "--binary=%s" % self.data.file.original_filename,
       "--patched-binary=patched.exe",
       "--patch-names=%s" % ",".join(names),
-    ], cwd=savedir, stderr=subprocess.PIPE)
+    ]
+
+    ogre = self.ogre.ogre
+    if ogre.functions:
+      name = filename("loader", "ogre")
+      with open(name, "w") as f:
+        f.write(str(ogre))
+        args.append("--ogre=%s" % name)
+
+    print("Running vibes-init in", savedir)
+    proc = subprocess.run(args, cwd=savedir, stderr=subprocess.PIPE)
     print("vibes-init exited with code", proc.returncode)
     if proc.returncode != 0:
       utils.eprint(proc.stderr.decode())

--- a/vibes-tools/tools/vibes-common-cli-options/lib/ogre.ml
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/ogre.ml
@@ -1,0 +1,10 @@
+module C = Cmdliner
+
+let ogre : string option C.Term.t =
+  let info = C.Arg.info ["O"; "ogre"]
+      ~docv:"OGRE"
+      ~doc:"Optional path/name of OGRE file for the binary" in
+  let parser = C.Arg.some' C.Arg.string in
+  let default = None in
+  let arg = C.Arg.opt parser default info in
+  C.Arg.value arg

--- a/vibes-tools/tools/vibes-common-cli-options/lib/ogre.mli
+++ b/vibes-tools/tools/vibes-common-cli-options/lib/ogre.mli
@@ -1,0 +1,2 @@
+(** The optional [ogre] specification of the binary. *)
+val ogre : string option Cmdliner.Term.t

--- a/vibes-tools/tools/vibes-init/bin/main.ml
+++ b/vibes-tools/tools/vibes-init/bin/main.ml
@@ -54,6 +54,7 @@ module Cli = struct
       (verbose : bool)
       (no_color : bool)
       (language : string option)
+      (ogre : string option)
       (model_filepath : string)
       (patch_names : string list)
       (binary : string)
@@ -66,6 +67,7 @@ module Cli = struct
       ~model_filepath
       ~binary
       ~patched_binary
+      ~ogre
       () |> function
     | Ok () -> Ok ()
     | Error e -> Error (KB.Conflict.to_string e)
@@ -75,6 +77,7 @@ module Cli = struct
       $ Cli_opts.Verbosity.verbose
       $ Cli_opts.Verbosity.no_color
       $ Cli_opts.Language.language_optional
+      $ Cli_opts.Ogre.ogre
       $ model_filepath
       $ patch_names
       $ binary

--- a/vibes-tools/tools/vibes-init/lib/runner.ml
+++ b/vibes-tools/tools/vibes-init/lib/runner.ml
@@ -12,20 +12,20 @@ module Inputs = Vibes_constants.Inputs
 let (let*) x f = Result.bind x ~f
 
 let run
+    ?(ogre : string option = None)
     ?(language : string option = None)
     ~(patch_names : string list)
     ~(model_filepath : string)
     ~(binary : string)
     ~(patched_binary : string)
     () : (unit, KB.conflict) result =
-  Log.send "Vibes_init.Runner.run '%s' '%s' '%s' '%s' '%s'"
+  Log.send "Vibes_init.Runner.run '%s' '%s' '%s' '%s'"
     (String.concat patch_names ~sep:", ") model_filepath binary
-    patched_binary (Option.value language ~default:"(none)");
+    patched_binary;
   let* language = match language with
-    | None -> Ok None
-    | Some language ->
-      Result.(CT.get_language language >>| Option.some) in
-  let* t = Types.create ~language ~patch_names
+    | Some language -> Result.(CT.get_language language >>| Option.some)
+    | None -> Ok None in
+  let* t = Types.create ~language ~patch_names ~ogre
       ~model:model_filepath ~binary ~patched_binary
       ~spaces:Inputs.default_patch_spaces in
   Log.send "Generating template files";

--- a/vibes-tools/tools/vibes-init/lib/runner.mli
+++ b/vibes-tools/tools/vibes-init/lib/runner.mli
@@ -3,6 +3,7 @@ open Bap_core_theory
 (** Runs the VIBES initializer; generates a Makefile for the project as
     well as empty/template files. *)
 val run :
+  ?ogre:string option ->
   ?language:string option ->
   patch_names:string list ->
   model_filepath:string ->

--- a/vibes-tools/tools/vibes-init/lib/types.mli
+++ b/vibes-tools/tools/vibes-init/lib/types.mli
@@ -21,10 +21,12 @@ type t = {
   patched_binary : string;
   patches : patch list;
   spaces : string;
+  ogre : string option;
 }
 
 (** Creates the information for generating the patch build process. *)
 val create :
+  ?ogre:string option ->
   ?language:Theory.language option ->
   patch_names:string list ->
   model:string ->

--- a/vibes-tools/tools/vibes-patch-info/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch-info/lib/types.mli
@@ -22,7 +22,7 @@ module Spaces : sig
   val is_empty : t -> bool
 
   (** Converts a list of spaces into an interval tree where
-      overlapping regions are coalesced. *)
+      overlapping and adjacent regions are coalesced. *)
   val of_list : space list -> t
 
   (** Returns the interval tree as a list of spaces. *)

--- a/vibes-tools/tools/vibes-patch/bin/main.ml
+++ b/vibes-tools/tools/vibes-patch/bin/main.ml
@@ -41,25 +41,16 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.required arg
 
-  let ogre : string option C.Term.t =
-    let info = C.Arg.info ["O"; "ogre"]
-        ~docv:"OGRE"
-        ~doc:"Optional path/name of OGRE file for the binary" in
-    let parser = C.Arg.some' C.Arg.string in
-    let default = None in
-    let arg = C.Arg.opt parser default info in
-    C.Arg.value arg
-
   let run
       (verbose : bool)
       (no_color : bool)
       (target : string)
       (language : string)
       (patch_spaces : string option)
+      (ogre : string option)
       (binary : string)
       (asm_filepaths : string list)
-      (patched_binary : string)
-      (ogre : string option) : (unit, string) result =
+      (patched_binary : string) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
     Log.send "Running 'vibes-as'";
     Runner.run
@@ -81,10 +72,10 @@ module Cli = struct
       $ Cli_opts.Target.target
       $ Cli_opts.Language.language
       $ Cli_opts.Patch_info.spaces
+      $ Cli_opts.Ogre.ogre
       $ binary
       $ asm_filepaths
       $ patched_binary
-      $ ogre
     )
 
   let cmd = C.Cmd.v info runner

--- a/vibes-tools/tools/vibes-patch/bin/main.ml
+++ b/vibes-tools/tools/vibes-patch/bin/main.ml
@@ -41,6 +41,15 @@ module Cli = struct
     let arg = C.Arg.opt parser default info in
     C.Arg.required arg
 
+  let ogre : string option C.Term.t =
+    let info = C.Arg.info ["O"; "ogre"]
+        ~docv:"OGRE"
+        ~doc:"Optional path/name of OGRE file for the binary" in
+    let parser = C.Arg.some' C.Arg.string in
+    let default = None in
+    let arg = C.Arg.opt parser default info in
+    C.Arg.value arg
+
   let run
       (verbose : bool)
       (no_color : bool)
@@ -49,7 +58,8 @@ module Cli = struct
       (patch_spaces : string option)
       (binary : string)
       (asm_filepaths : string list)
-      (patched_binary : string) : (unit, string) result =
+      (patched_binary : string)
+      (ogre : string option) : (unit, string) result =
     let () = Cli_opts.Verbosity.setup ~verbose ~no_color in
     Log.send "Running 'vibes-as'";
     Runner.run
@@ -59,6 +69,7 @@ module Cli = struct
       ~binary
       ~asm_filepaths
       ~patched_binary
+      ~ogre
       () |> function
     | Ok () -> Ok ()
     | Error e -> Error (KB.Conflict.to_string e)
@@ -73,6 +84,7 @@ module Cli = struct
       $ binary
       $ asm_filepaths
       $ patched_binary
+      $ ogre
     )
 
   let cmd = C.Cmd.v info runner

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -537,7 +537,7 @@ module Extend_ogre = struct
     let len = of_int @@ String.length patch.data in
     let data_len = of_int patch.inline in
     let code_len = len - data_len in
-    if len > code_len then
+    if data_len > 0L then
       let addr = patch.addr + code_len in
       let loc = patch.loc + code_len in
       Ogre.sequence [

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -15,8 +15,8 @@ module Dis = Disasm_expert.Basic
 type dis = (Dis.asm, Dis.kinds) Dis.t
 
 let (let*) x f = Result.bind x ~f
+let (@.) = Fn.compose
 
-type spaces = Patch_info.space list
 type target = (module Types.Target)
 
 let target_info
@@ -37,56 +37,58 @@ let target_info
   | Error err ->
     Error (Errors.No_disasm (Format.asprintf "%a" Error.pp err))
 
-type overwrite = {
-  dis    : dis;
-  memmap : value memmap;
-}
+(* Find the code segment in the binary, and see how much room we have
+   for extending it when we need more space. *)
+module Code_seg = struct
 
-type code_seg_alloc = {
-  addr : int64;
-  size : int64;
-  end_ : int64;
-  off  : int64;
-  room : int64;
-}
-
-let find_code_segment_alloc (spec : Ogre.doc) : code_seg_alloc option =
-  let open Int64 in
-  let (let*) x f = Option.bind x ~f in
-  let query = Ogre.Query.(select @@ from Image.Scheme.segment) in
-  let* segs = Ogre.eval (Ogre.collect query) spec |> Or_error.ok in
-  let* code_addr, code_size = Seq.find_map segs ~f:(fun seg ->
-      let {Image.Scheme.addr; size; info=(_,_,x)} = seg in
-      Option.some_if x (addr, size)) in
-  let* region = Utils.find_mapped_region code_addr spec in
-  let code_end = code_addr + code_size in
-  let closer x y = x - code_end < y - code_end in
-  let next_addr = Seq.fold segs ~init:None ~f:(fun acc seg ->
-      let {Image.Scheme.addr; _} = seg in
-      if addr >= code_end then match acc with
-        | Some a when closer addr a -> Some addr
-        | Some _ -> acc
-        | None -> Some addr
-      else acc) in
-  let size = match next_addr with
-    | Some a -> a - code_end
-    | None -> 0L in
-  Log.send "Code segment end = 0x%Lx, available space = %Ld bytes"
-    code_end size;
-  Some {
-    addr = code_addr;
-    size = code_size;
-    end_ = code_end;
-    off  = region.offset;
-    room = size;
+  type t = {
+    addr : int64;
+    size : int64;
+    end_ : int64;
+    off  : int64;
+    room : int64;
   }
+
+  let find (spec : Ogre.doc) : t option =
+    let open Int64 in
+    let (let*) x f = Option.bind x ~f in
+    let query = Ogre.Query.(select @@ from Image.Scheme.segment) in
+    let* segs = Ogre.eval (Ogre.collect query) spec |> Or_error.ok in
+    let* code_addr, code_size = Seq.find_map segs ~f:(fun seg ->
+        let {Image.Scheme.addr; size; info=(_,_,x)} = seg in
+        Option.some_if x (addr, size)) in
+    let* region = Utils.find_mapped_region code_addr spec in
+    let code_end = code_addr + code_size in
+    let closer x y = x - code_end < y - code_end in
+    let next_addr = Seq.fold segs ~init:None ~f:(fun acc seg ->
+        let {Image.Scheme.addr; _} = seg in
+        if addr >= code_end then match acc with
+          | Some a when closer addr a -> Some addr
+          | Some _ -> acc
+          | None -> Some addr
+        else acc) in
+    let size = match next_addr with
+      | Some a -> a - code_end
+      | None -> 0L in
+    Log.send "Code segment end = 0x%Lx, available space = %Ld bytes"
+      code_end size;
+    Some {
+      addr = code_addr;
+      size = code_size;
+      end_ = code_end;
+      off  = region.offset;
+      room = size;
+    }
+
+end
 
 type info = {
   spec     : Ogre.doc;
   target   : target;
   language : T.language;
-  o        : overwrite;
-  code     : code_seg_alloc;
+  dis      : dis;
+  memmap   : value memmap;
+  code     : Code_seg.t;
 }
 
 let create_info
@@ -95,65 +97,9 @@ let create_info
     (target : T.target)
     (language : T.language) : (info, KB.conflict) result =
   let* dis, target = target_info target language in
-  match find_code_segment_alloc spec with
+  match Code_seg.find spec with
   | None -> Error (Errors.No_code_segment "No code segment found")
-  | Some code -> Ok {spec; target; language; o = {dis; memmap}; code}
-
-let find_mem
-    (target : T.target)
-    (addr : int64)
-    (size : int64)
-    (memmap : value memmap) : (mem, KB.conflict) result =
-  let open Int64 in
-  let len_ok mem = size <= of_int (Memory.length mem) in
-  let width = T.Target.code_addr_size target in
-  let from = Word.of_int64 ~width addr in
-  Memmap.to_sequence memmap |> Seq.find_map ~f:(fun (mem, _) ->
-      if Memory.contains mem from && len_ok mem then
-        Memory.view mem ~from |> Result.ok
-      else None) |> function
-  | Some mem -> Ok mem
-  | None ->
-    let msg = Format.asprintf
-        "Couldn't find memory of at least size %Ld for patch point %a"
-        size Word.pp from in
-    Error (Errors.Invalid_address msg)
-
-let overwritten
-    (o : overwrite)
-    (target : T.target)
-    (addr : int64)
-    (size : int64) : (string list * int64, KB.conflict) result =
-  let open Int64 in
-  let invalid_size t =
-    let msg = Format.asprintf
-        "Invalid size %Ld at 0x%Lx (%Ld bytes disassembled)"
-        addr size t in
-    Error (Errors.Invalid_size msg) in
-  let rec disasm acc mem t n = match Dis.insn_of_mem o.dis mem with
-    | Error err ->
-      let msg = Format.asprintf "Disasm error: %a" Error.pp err in
-      Error (Errors.Invalid_insn msg)
-    | Ok (_, None, _) ->
-      (* The bytes at this address failed to decode to a valid instruction,
-         but we should just assume that it's free space (i.e. inline data)
-         and that the user intends to overwrite this region. *)
-      Ok (List.rev acc, t)
-    | Ok (m, Some insn, next) ->
-      let len = of_int @@ Memory.length m in
-      let n = n - len and t = t + len in
-      let asm = Dis.Insn.asm insn in
-      if n = 0L then Ok (List.rev (asm :: acc), t)
-      else match next with
-        | `finished -> invalid_size t
-        | `left _ when n < 0L -> Ok (List.rev (asm :: acc), t)
-        | `left mem -> disasm (asm :: acc) mem t n in
-  let* mem = find_mem target addr size o.memmap in
-  let* insns, n = disasm [] mem 0L size in
-  if not @@ List.is_empty insns then
-    Log.send "The following instructions will be overwritten at 0x%Lx:\n%s\n"
-      addr @@ String.concat insns ~sep:"\n";
-  Ok (insns, n)
+  | Some code -> Ok {spec; target; language; dis; memmap; code}
 
 type patch = {
   data       : string;
@@ -174,6 +120,76 @@ let pp_patch (ppf : Format.formatter) (p : patch) : unit =
                       trampoline=%b"
     p.addr p.loc len p.inline p.root p.trampoline
 
+(* If the patch placement overwrites instructions that need to be
+   preserved in the binary, then we will disassemble those instructions
+   and use them as part of the patch assembly.
+
+   TODO: what if the overwritten instructions have PC-relative operands?
+   If we try to place them at a different location in the binary then it
+   would probably break the behavior. The easy solution is to fail and
+   then tell the user that they picked a bad patch point.
+*)
+module Overwritten = struct
+
+  let find_mem
+      (target : T.target)
+      (addr : int64)
+      (size : int64)
+      (memmap : value memmap) : (mem, KB.conflict) result =
+    let open Int64 in
+    let len_ok mem = size <= of_int (Memory.length mem) in
+    let width = T.Target.code_addr_size target in
+    let from = Word.of_int64 ~width addr in
+    Memmap.to_sequence memmap |> Seq.find_map ~f:(fun (mem, _) ->
+        if Memory.contains mem from && len_ok mem then
+          Memory.view mem ~from |> Result.ok
+        else None) |> function
+    | Some mem -> Ok mem
+    | None ->
+      let msg = Format.asprintf
+          "Couldn't find memory of at least size %Ld for patch point %a"
+          size Word.pp from in
+      Error (Errors.Invalid_address msg)
+
+  let go
+      (dis : dis)
+      (memmap : value memmap)
+      (target : T.target)
+      (addr : int64)
+      (size : int64) : (string list * int64, KB.conflict) result =
+    let open Int64 in
+    let invalid_size t =
+      let msg = Format.asprintf
+          "Invalid size %Ld at 0x%Lx (%Ld bytes disassembled)"
+          addr size t in
+      Error (Errors.Invalid_size msg) in
+    let rec disasm acc mem t n = match Dis.insn_of_mem dis mem with
+      | Error err ->
+        let msg = Format.asprintf "Disasm error: %a" Error.pp err in
+        Error (Errors.Invalid_insn msg)
+      | Ok (_, None, _) ->
+        (* The bytes at this address failed to decode to a valid instruction,
+           but we should just assume that it's free space (i.e. inline data)
+           and that the user intends to overwrite this region. *)
+        Ok (List.rev acc, t)
+      | Ok (m, Some insn, next) ->
+        let len = of_int @@ Memory.length m in
+        let n = n - len and t = t + len in
+        let asm = Dis.Insn.asm insn in
+        if n = 0L then Ok (List.rev (asm :: acc), t)
+        else match next with
+          | `finished -> invalid_size t
+          | `left _ when n < 0L -> Ok (List.rev (asm :: acc), t)
+          | `left mem -> disasm (asm :: acc) mem t n in
+    let* mem = find_mem target addr size memmap in
+    let* insns, n = disasm [] mem 0L size in
+    if not @@ List.is_empty insns then
+      Log.send "The following instructions will be overwritten at 0x%Lx:\n%s\n"
+        addr @@ String.concat insns ~sep:"\n";
+    Ok (insns, n)
+
+end
+
 module Elf = struct
 
   include Elf
@@ -192,8 +208,8 @@ module Elf = struct
     let rd32be pos = Bigstring.get_int32_t_be data ~pos |> of_int32 in
     let rd64le pos = Bigstring.get_int64_t_le data ~pos in
     let rd64be pos = Bigstring.get_int64_t_be data ~pos in
-    let wr32le pos v = Bigstring.set_int32_t_le data ~pos @@ to_int32_trunc v in
-    let wr32be pos v = Bigstring.set_int32_t_be data ~pos @@ to_int32_trunc v in
+    let wr32le pos = Bigstring.set_int32_t_le data ~pos @. to_int32_trunc in
+    let wr32be pos = Bigstring.set_int32_t_be data ~pos @. to_int32_trunc in
     let wr64le pos = Bigstring.set_int64_t_le data ~pos in
     let wr64be pos = Bigstring.set_int64_t_be data ~pos in
     let rd16, rd, wr, fs, ms, ps, po = match elf.e_class, elf.e_data with
@@ -231,8 +247,277 @@ module Elf = struct
 
 end
 
+module Placement = struct
+
+  (* The available space after the code segment won't be marked by BAP
+     as a valid code region, so we will pretend it exists.
+
+     We look for code regions in the OGRE doc under the assumption that
+     not all mapped regions will be code (or even executable), therefore
+     if the user tried to place a patch in a non-code region we would
+     end up with a broken binary.
+  *)
+  let extern_region (info : info) (addr : int64) : Utils.region option =
+    let open Int64 in
+    if addr >= info.code.end_
+    && addr < info.code.end_ + info.code.room then Some Utils.{
+        addr = info.code.end_;
+        size = info.code.room;
+        offset = info.code.off + info.code.size;
+      } else Utils.find_code_region addr info.spec
+
+  (* Get the raw binary data of the patch at the specified patch site. *)
+  let situate
+      (info : info)
+      (asm : Asm.t)
+      (org : int64 option)
+      (to_addr : int64 -> int64)
+      (loc : int64)
+      (overwritten : string list)
+      (jmp : int64 option) : (string * int, KB.conflict) result =
+    let module Target = (val info.target) in
+    let asm' = Target.situate asm ~loc ~to_addr ~org ~jmp ~overwritten in
+    Log.send "Situated assembly at 0x%Lx:\n%a" (to_addr loc) Asm.pp asm';
+    let* objfile, inline_data = Target.Toolchain.assemble asm' info.language in
+    let* data = Target.Toolchain.to_binary objfile in
+    (* If the origin was adjusted then shave off those bytes. *)
+    let data = match org with
+      | Some org -> String.drop_prefix data @@ Int64.to_int_exn org
+      | None -> data in
+    Ok (data, inline_data)
+
+  (* Try to fit the patch into the specified patch site. *)
+  let try_site
+      ?(trampoline : bool = false)
+      ?(extern : bool = false)
+      ?(ret : int64 option)
+      ?(overwritten : string list = [])
+      (info : info)
+      (region : Utils.region)
+      (addr : int64)
+      (size : int64)
+      (asm : Asm.t) : (patch option, KB.conflict) result =
+    let open Int64 in
+    let module Target = (val info.target) in
+    let root = asm.patch_point in
+    let loc = Utils.addr_to_offset addr region in
+    let to_addr loc = Utils.offset_to_addr loc region in
+    let org = Target.adjusted_org addr in
+    let situate = situate info asm org to_addr loc overwritten in
+    let end_jmp = Target.ends_in_jump asm in
+    let inline_data = Target.has_inline_data asm in
+    let needs_jmp = not end_jmp && (extern || inline_data) in
+    let* data, inline = situate @@ match ret with
+      | Some _ when needs_jmp -> ret
+      | None when needs_jmp -> assert false
+      | None | Some _ -> None in
+    match of_int @@ String.length data with
+    | len when len = size ->
+      (* The patch uses exactly the available space. *)
+      Ok (Some {data; addr; loc; inline; root; trampoline})
+    | len when len < size && (end_jmp || needs_jmp) ->
+      (* We have some space left over, but the patch already has
+         a jump at the end. *)
+      Ok (Some {data; addr; loc; inline; root; trampoline})
+    | len when len < size ->
+      (* For patching at the original location, we need to insert
+         a jump to the end of the specified space. We need to check
+         that the patch still fits because inserting a jump will
+         increase the length of the patch. *)
+      Log.send "Patch has %Ld bytes of space remaining, \
+                requires a jump" (size - len);
+      let* data, inline = situate @@ match ret with
+        | None -> assert false
+        | Some _ -> ret in
+      Result.return begin match of_int @@ String.length data with
+        | len when len <= size ->
+          Some {data; addr; loc; inline; root; trampoline}
+        | len ->
+          Log.send "Patch doesn't fit at address 0x%Lx (%Ld bytes \
+                    available, %Ld bytes needed)" addr size len;
+          None
+      end
+    | len ->
+      Log.send "Patch doesn't fit at address 0x%Lx (%Ld bytes \
+                available, %Ld bytes needed)" addr size len;
+      Ok None
+
+  let collect_overwritten
+      (info : info)
+      (patch : patch)
+      (patch_name : string)
+      (addr : int64)
+      (size : int64) : (string list * int64, KB.conflict) result =
+    let open Int64 in
+    let module Target = (val info.target) in
+    (* Bytes required for the patch. *)
+    let len = of_int @@ String.length patch.data in
+    Log.send "%s fits (%Ld bytes)" patch_name len;
+    (* If the patch is bigger than the number of bytes
+       we intended to replace, then we need to disassemble
+       the remaining instructions that would have been
+       overwritten. *)
+    let osize = len - size in
+    if osize > 0L then
+      (* Start at the end of the instructions that we intended
+         to overwrite. *)
+      let oaddr = addr + size in
+      Log.send "%Ld bytes remain, need to disassemble at 0x%Lx"
+        osize oaddr;
+      Overwritten.go info.dis info.memmap Target.target oaddr osize
+    else Ok ([], size)
+
+  (* Using an external patch space requires a trampoline. *)
+  type extern = {
+    patch      : patch;
+    trampoline : patch;
+  }
+
+  type spaces = Patch_info.space list
+
+  (* Try the provided external patch spaces. *)
+  let rec extern
+      (info : info)
+      (orig_region : Utils.region)
+      (asm : Asm.t)
+      (addr : int64)
+      (size : int64) : spaces -> (extern, KB.conflict) result = function
+    | [] -> Error (Errors.No_patch_spaces "No suitable patch spaces found")
+    | space :: rest ->
+      let open Int64 in
+      let module Target = (val info.target) in
+      let jumpto = Bitvec.to_int64 @@ Word.to_bitvec space.address in
+      let next () = extern info orig_region asm addr size rest in
+      Log.send "Attempting patch space 0x%Lx with %Ld bytes of space"
+        jumpto space.size;
+      match extern_region info jumpto with
+      | None ->
+        Log.send "Code region for patch space at address \
+                  0x%Lx was not found" jumpto;
+        next ()
+      | Some region ->
+        (* We have to make sure that the jump to the external space
+           will fit at the intended patch point. *)
+        Log.send "Found region (addr=0x%Lx, size=%Ld, offset=0x%Lx), \
+                  attempting to situate trampoline"
+          region.addr region.size region.offset;
+        let* trampoline =
+          let maxlen = of_int Target.max_insn_length in
+          let asm = Target.create_trampoline jumpto addr size in
+          try_site info orig_region addr maxlen asm ~trampoline:true in
+        let trampoline_name = Format.sprintf "Trampoline 0x%Lx" addr in
+        match trampoline with
+        | None ->
+          Log.send "%s doesn't fit" trampoline_name;
+          next ()
+        | Some trampoline ->
+          let* overwritten, n =
+            collect_overwritten info trampoline trampoline_name addr size in
+          let* patch = try_site info region jumpto space.size asm
+              ~overwritten ~extern:true ~ret:(addr + n) in
+          match patch with
+          | Some patch -> Ok {patch; trampoline}
+          | None -> next ()
+
+  type placed =
+    | Local of patch
+    | Extern of extern
+
+  (* Search for a space in the binary where the patch will fit. We first
+     try the provided patch point, and if it doesn't work we will try the
+     available external patch spaces that the user gave us. *)
+  let place_one
+      (info : info)
+      (patch_spaces : spaces)
+      (asm : Asm.t) : (placed, KB.conflict) result =
+    let open Int64 in
+    let module Target = (val info.target) in
+    let addr, size = asm.patch_point, asm.patch_size in
+    Log.send "Attempting patch point 0x%Lx with %Ld bytes of space" addr size;
+    let* region = match Utils.find_code_region addr info.spec with
+      | Some region -> Ok region
+      | None ->
+        let msg = Format.sprintf
+            "Couldn't find code region for patch point 0x%Lx"
+            addr in
+        Error (Errors.Invalid_address msg) in
+    Log.send "Found region (addr=0x%Lx, size=%Ld, offset=0x%Lx)"
+      region.addr region.size region.offset;
+    let* patch =
+      if size > 0L then
+        try_site info region addr size asm ~ret:(addr + size)
+      else begin
+        Log.send "Patch size is zero, need external patch space";
+        Ok None
+      end in
+    match patch with
+    | Some patch -> Ok (Local patch)
+    | None ->
+      let* e = extern info region asm addr size patch_spaces in
+      Ok (Extern e)
+
+  (* Find the space that was used for the patch, and consume that part of it.
+     If there is no more space left, then remove it from the list. *)
+  let consume (patch : patch) (spaces : spaces) : spaces =
+    List.filter_map spaces ~f:(fun space ->
+        let open Int64 in
+        let Patch_info.{address; size} = space in
+        let width = Word.bitwidth address in
+        let address = Bitvec.to_int64 @@ Word.to_bitvec address in
+        if patch.addr = address then
+          let patch_size = of_int @@ String.length patch.data in
+          let size = size - patch_size in
+          if size > 0L then
+            let address = Word.of_int64 ~width (address + patch_size) in
+            Some Patch_info.{address; size}
+          else None
+        else Some space)
+
+  type asms = Asm.t list
+
+  (* - `patches` is the list of patches that were successfully placed.
+
+     - `spaces` is the list of external patch sites after placement,
+       where the space has been consumed.
+
+     - `remaining` is the list of patches (in assembly) that have not
+       been placed yet.
+  *)
+  type t = {
+    patches   : patch list;
+    spaces    : spaces;
+    remaining : asms;
+  }
+
+  let rec go
+      ?(acc : patch list = [])
+      (info : info)
+      (spaces : spaces) : asms -> (t, KB.conflict) result = function
+    | [] -> Ok {patches = List.rev acc; spaces; remaining = []}
+    | (asm :: rest) as asms -> match place_one info spaces asm with
+      | Error (Errors.No_patch_spaces _) ->
+        (* We ran out of room, but we can try to create space in the
+           binary later. *)
+        Ok {patches = List.rev acc; spaces; remaining = asms}
+      | Error _ as err -> err
+      | Ok (Local patch) ->
+        Log.send "Solved patch placement: %a" pp_patch patch;
+        go info spaces rest ~acc:(patch :: acc)
+      | Ok (Extern {patch; trampoline = t}) ->
+        Log.send "Solved patch placement: %a" pp_patch patch;
+        Log.send "Trampoline: %a" pp_patch t;
+        go info (consume patch spaces) rest ~acc:(t :: patch :: acc)
+
+end
+
+type t = {
+  patches  : patch list;
+  spaces   : Spaces.t;
+  new_ogre : Ogre.doc option;
+}
+
 (* Copy the original binary and write the patches to it. *)
-let patch_file
+let write
     ?(extend : int64 = 0L)
     (code_seg_addr : int64)
     (patches : patch list)
@@ -253,243 +538,6 @@ let patch_file
           Out_channel.seek file patch.loc;
           Out_channel.output_string file patch.data))
 
-(* Get the raw binary data of the patch at the specified patch site. *)
-let try_patch_site_aux
-    (info : info)
-    (asm : Asm.t)
-    (org : int64 option)
-    (to_addr : int64 -> int64)
-    (loc : int64)
-    (overwritten : string list)
-    (jmp : int64 option) : (string * int, KB.conflict) result =
-  let module Target = (val info.target) in
-  let asm' = Target.situate asm ~loc ~to_addr ~org ~jmp ~overwritten in
-  Log.send "Situated assembly at 0x%Lx:\n%a" (to_addr loc) Asm.pp asm';
-  let* objfile, inline_data = Target.Toolchain.assemble asm' info.language in
-  let* data = Target.Toolchain.to_binary objfile in
-  (* If the origin was adjusted then shave off those bytes. *)
-  let data = match org with
-    | Some org -> String.drop_prefix data @@ Int64.to_int_exn org
-    | None -> data in
-  Ok (data, inline_data)
-
-(* Try to fit the patch into the specified patch site. *)
-let try_patch_site
-    ?(trampoline : bool = false)
-    ?(extern : bool = false)
-    (info : info)
-    (region : Utils.region)
-    (addr : int64)
-    (size : int64)
-    (ret : int64 option)
-    (asm : Asm.t)
-    (overwritten : string list) : (patch option, KB.conflict) result =
-  let open Int64 in
-  let module Target = (val info.target) in
-  let root = asm.patch_point in
-  let loc = Utils.addr_to_offset addr region in
-  let to_addr loc = Utils.offset_to_addr loc region in
-  let org = Target.adjusted_org addr in
-  let try_ = try_patch_site_aux info asm org to_addr loc overwritten in
-  let end_jmp = Target.ends_in_jump asm in
-  let inline_data = Target.has_inline_data asm in
-  let needs_jmp = not end_jmp && (extern || inline_data) in
-  let* data, inline = try_ @@ match ret with
-    | Some _ when needs_jmp -> ret
-    | None when needs_jmp -> assert false
-    | None | Some _ -> None in
-  match of_int @@ String.length data with
-  | len when len = size ->
-    Ok (Some {data; addr; loc; inline; root; trampoline})
-  | len when len < size && (end_jmp || needs_jmp) ->
-    Ok (Some {data; addr; loc; inline; root; trampoline})
-  | len when len < size ->
-    (* For patching at the original location, we need to insert
-       a jump to the end of the specified space. We need to check
-       that the patch still fits because inserting a jump will
-       increase the length of the patch. *)
-    Log.send "Patch has %Ld bytes of space remaining, \
-              requires a jump" (size - len);
-    let* data, inline = try_ @@ match ret with
-      | None -> assert false
-      | Some _ -> ret in
-    Result.return begin match of_int @@ String.length data with
-      | len when len <= size ->
-        Some {data; addr; loc; inline; root; trampoline}
-      | len ->
-        Log.send "Patch doesn't fit at address 0x%Lx (%Ld bytes \
-                  available, %Ld bytes needed)" addr size len;
-        None
-    end
-  | len ->
-    Log.send "Patch doesn't fit at address 0x%Lx (%Ld bytes \
-              available, %Ld bytes needed)" addr size len;
-    Ok None
-
-(* The available space after the code segment won't be marked by BAP
-   as a valid code region, so we will pretend it exists.
-
-   We look for code regions in the OGRE doc under the assumption that
-   not all mapped regions will be code (or even executable), therefore
-   if the user tried to place a patch in a non-code region we would
-   end up with a broken binary.
-*)
-let extern_region (info : info) (addr : int64) : Utils.region option =
-  let open Int64 in
-  if addr >= info.code.end_
-  && addr < info.code.end_ + info.code.room then Some Utils.{
-      addr = info.code.end_;
-      size = info.code.room;
-      offset = info.code.off + info.code.size;
-    } else Utils.find_code_region addr info.spec
-
-let collect_overwritten
-    (info : info)
-    (patch : patch)
-    (patch_name : string)
-    (addr : int64)
-    (size : int64) : (string list * int64, KB.conflict) result =
-  let open Int64 in
-  let module Target = (val info.target) in
-  (* Bytes required for the patch. *)
-  let len = of_int @@ String.length patch.data in
-  Log.send "%s fits (%Ld bytes)" patch_name len;
-  (* If the patch is bigger than the number of bytes
-     we intended to replace, then we need to disassemble
-     the remaining instructions that would have been
-     overwritten. *)
-  let osize = len - size in
-  if osize > 0L then
-    (* Start at the end of the instructions that we intended
-       to overwrite. *)
-    let oaddr = addr + size in
-    Log.send "%Ld bytes remain, need to disassemble at 0x%Lx"
-      osize oaddr;
-    overwritten info.o Target.target oaddr osize
-  else Ok ([], size)
-
-(* Try the provided external patch spaces. *)
-let rec try_patch_spaces
-    (info : info)
-    (orig_region : Utils.region)
-    (asm : Asm.t)
-    (addr : int64)
-    (size : int64) : spaces -> ((patch * patch), KB.conflict) result = function
-  | [] -> Error (Errors.No_patch_spaces "No suitable patch spaces found")
-  | space :: rest ->
-    let open Int64 in
-    let module Target = (val info.target) in
-    let jumpto = Bitvec.to_int64 @@ Word.to_bitvec space.address in
-    let next () = try_patch_spaces info orig_region asm addr size rest in
-    Log.send "Attempting patch space 0x%Lx with %Ld bytes of space"
-      jumpto space.size;
-    match extern_region info jumpto with
-    | None ->
-      Log.send "Code region for patch space at address \
-                0x%Lx was not found" jumpto;
-      next ()
-    | Some region ->
-      (* We have to make sure that the jump to the external space
-         will fit at the intended patch point. *)
-      Log.send "Found region (addr=0x%Lx, size=%Ld, offset=0x%Lx), \
-                attempting to situate trampoline"
-        region.addr region.size region.offset;
-      let* trampoline =
-        let maxlen = of_int Target.max_insn_length in
-        let asm = Target.create_trampoline jumpto addr size in
-        try_patch_site info orig_region addr maxlen None asm []
-          ~trampoline:true in
-      match trampoline with
-      | None ->
-        Log.send "Trampoline doesn't fit";
-        next ()
-      | Some trampoline ->
-        let* overwritten, n =
-          collect_overwritten info trampoline "Trampoline" addr size in
-        let* patch =
-          try_patch_site info region jumpto
-            space.size (Some (addr + n))
-            asm overwritten ~extern:true in
-        match patch with
-        | Some patch -> Ok (patch, trampoline)
-        | None -> next ()
-
-(* Search for a space in the binary where the patch will fit. We first
-   try the provided patch point, and if it doesn't work we will try the
-   available external patch spaces that the user gave us. *)
-let place_patch
-    (info : info)
-    (patch_spaces : spaces)
-    (asm : Asm.t) : (patch * patch option, KB.conflict) result =
-  let open Int64 in
-  let module Target = (val info.target) in
-  let addr, size = asm.patch_point, asm.patch_size in
-  Log.send "Attempting patch point 0x%Lx with %Ld bytes of space" addr size;
-  let* region = match Utils.find_code_region addr info.spec with
-    | Some region -> Ok region
-    | None ->
-      let msg = Format.sprintf
-          "Couldn't find code region for patch point 0x%Lx"
-          addr in
-      Error (Errors.Invalid_address msg) in
-  Log.send "Found region (addr=0x%Lx, size=%Ld, offset=0x%Lx)"
-    region.addr region.size region.offset;
-  let* patch =
-    if size > 0L then
-      try_patch_site info region addr size (Some (addr + size)) asm []
-    else begin
-      Log.send "Patch size is zero, need external patch space";
-      Ok None
-    end in
-  match patch with
-  | Some patch -> Ok (patch, None)
-  | None ->
-    let* patch, trampoline =
-      try_patch_spaces info region asm addr size patch_spaces in
-    Ok (patch, Some trampoline)
-
-let consume_space (patch : patch) (spaces : spaces) : spaces =
-  List.filter_map spaces ~f:(fun space ->
-      let open Int64 in
-      let Patch_info.{address; size} = space in
-      let width = Word.bitwidth address in
-      let address = Bitvec.to_int64 @@ Word.to_bitvec address in
-      if patch.addr = address then
-        let patch_size = of_int @@ String.length patch.data in
-        let size = size - patch_size in
-        if size > 0L then
-          let address = Word.of_int64 ~width (address + patch_size) in
-          Some Patch_info.{address; size}
-        else None
-      else Some space)
-
-type asms = Asm.t list
-type batch = patch list * spaces * asms
-
-type res = {
-  patches : patch list;
-  spaces : Spaces.t;
-  new_ogre : Ogre.doc option;
-}
-
-let rec place_and_consume
-    ?(acc : patch list = [])
-    (info : info)
-    (spaces : spaces) : asms -> (batch, KB.conflict) result = function
-  | [] -> Ok (List.rev acc, spaces, [])
-  | ((asm : Asm.t) :: rest) as asms -> match place_patch info spaces asm with
-    | Error (Errors.No_patch_spaces _) ->
-      Ok (List.rev acc, spaces, asms)
-    | Error _ as err -> err
-    | Ok (patch, trampoline) ->
-      Log.send "Solved patch placement: %a" pp_patch patch;
-      Option.iter trampoline ~f:(Log.send "Trampoline: %a" pp_patch);
-      let acc = match trampoline with
-        | Some t -> t :: patch :: acc
-        | None -> patch :: acc in
-      let spaces = consume_space patch spaces in
-      place_and_consume info spaces rest ~acc
-
 let patch
     ?(ogre : Ogre.doc option = None)
     ?(patch_spaces : Spaces.t = Spaces.empty)
@@ -497,7 +545,7 @@ let patch
     (language : T.language)
     (asms : Asm.t list)
     ~(binary : string)
-    ~(patched_binary : string) : (res, KB.conflict) result =
+    ~(patched_binary : string) : (t, KB.conflict) result =
   Log.send "Loading binary %s" binary;
   let* image = Vibes_utils.Loader.image binary in
   let memmap = Image.memory image in
@@ -506,10 +554,14 @@ let patch
   Log.send "Solving patch placement";
   let spaces = Spaces.to_list patch_spaces in
   let had_spaces = not @@ List.is_empty spaces in
-  let* patches, spaces, remaining = place_and_consume info spaces asms in
-  let* patches, extend = match remaining with
-    | [] -> Ok (patches, 0L)
-    | _ ->
+  let* placement = Placement.go info spaces asms in
+  let* patches, extend = match placement.remaining with
+    | [] -> Ok (placement.patches, 0L)
+    | remaining ->
+      (* Either the user didn't give us any external patch spaces
+         or we used up all the available space. Our last resort is
+         to increase the size of the code segment so that we can
+         place the remaining patches there. *)
       if had_spaces
       then Log.send "Ran out of patch spaces"
       else Log.send "No patch spaces provided";
@@ -519,18 +571,18 @@ let patch
           address = Word.of_int64 ~width info.code.end_;
           size = info.code.room;
         } in
-      let* rest, spaces, asms = place_and_consume info [space] remaining in
-      match asms with
-      | _ :: _ ->
-        Error (Errors.No_patch_spaces "Not enough space to extend \
-                                       the code segment")
-      | [] ->
+      let* rest = Placement.go info [space] remaining in
+      if List.is_empty rest.remaining then
         let open Int64 in
-        let extend = match spaces with
+        (* Find out how many bytes by which we need to extend the
+           code segment. *)
+        let extend = match rest.spaces with
           | [] -> info.code.room
           | s :: _ -> Word.to_int64_exn s.address - info.code.end_ in
-        Ok (patches @ rest, extend) in
-  let* () =
-    Log.send "Writing to patched binary %s" patched_binary;
-    patch_file info.code.addr patches binary patched_binary ~extend in
+        Ok (placement.patches @ rest.patches, extend) 
+      else
+        let msg = "Not enough space to extend the code segment" in
+        Error (Errors.No_patch_spaces msg) in
+  Log.send "Writing to patched binary %s" patched_binary;
+  let* () = write info.code.addr patches binary patched_binary ~extend in
   Ok {patches; spaces = Spaces.of_list spaces; new_ogre = ogre}

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -572,12 +572,12 @@ module Extend_ogre = struct
       | Some name ->
         let name = Format.sprintf "%s@%Lx" name patch.addr in
         match Ogre.exec (provide patch name region.addr) ogre with
+        | Ok _ as res -> res
         | Error err ->
           let msg = Format.asprintf
               "Failed to extend OGRE file for patch 0x%Lx, root 0x%Lx: %a"
               patch.addr patch.root Error.pp err in
           Error (Errors.Invalid_ogre msg)
-        | Ok _ as res -> res
 
   let rec go (ogre : Ogre.doc) : patch list -> res = function
     | [] -> Ok ogre

--- a/vibes-tools/tools/vibes-patch/lib/patcher.mli
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.mli
@@ -2,21 +2,33 @@ open Bap_core_theory
 
 (** A placed patch. *)
 type patch = {
-  data : string;
-  addr : int64;
-  loc : int64;
+  data       : string;
+  addr       : int64;
+  loc        : int64;
+  inline     : int;
+  root       : int64;
+  trampoline : bool;
 }
 
-type res = patch list * Vibes_patch_info.Types.Spaces.t
+type res = {
+  patches  : patch list;
+  spaces   : Vibes_patch_info.Types.Spaces.t;
+  new_ogre : Ogre.doc option;
+}
 
-(** [patch target language asms ~binary ~patched_binary ~backend ?spaces] will
-    assemble and place a list of patches in the original [binary], whose contents
-    are written to the file at path [patched_binary].
+(** [patch target language asms ~binary ~patched_binary ~backend ?spaces ?ogre]
+    will assemble and place a list of patches in the original [binary], whose
+    contents are written to the file at path [patched_binary].
 
     The result is the list of patches applied to the binary, as well as the
     resulting list of external spaces that are now occupied.
+
+    The if the optional [ogre] specification is supplied, then a new
+    specification will be returned if patching is successful, which shall
+    contain extra information about patch spaces that were used.
 *)
 val patch :
+  ?ogre:Ogre.doc option ->
   ?patch_spaces:Vibes_patch_info.Types.Spaces.t ->
   Theory.target ->
   Theory.language ->

--- a/vibes-tools/tools/vibes-patch/lib/patcher.mli
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.mli
@@ -10,7 +10,8 @@ type patch = {
   trampoline : bool;
 }
 
-type res = {
+(** The result. *)
+type t = {
   patches  : patch list;
   spaces   : Vibes_patch_info.Types.Spaces.t;
   new_ogre : Ogre.doc option;
@@ -35,4 +36,4 @@ val patch :
   Vibes_as.Types.Assembly.t list ->
   binary:string ->
   patched_binary:string ->
-  (res, KB.conflict) result
+  (t, KB.conflict) result

--- a/vibes-tools/tools/vibes-patch/lib/runner.ml
+++ b/vibes-tools/tools/vibes-patch/lib/runner.ml
@@ -54,10 +54,11 @@ let run
     patched_binary;
   let* target = CT.get_target target in
   let* language = CT.get_language language in
-  let had_spaces = Option.is_some patch_spaces in
-  let* patch_spaces = match patch_spaces with
-    | Some path -> Spaces.from_file path
-    | None -> Ok Spaces.empty in
+  let* patch_spaces, had_spaces = match patch_spaces with
+    | None -> Ok (Spaces.empty, false)
+    | Some path ->
+      let* spaces = Spaces.from_file path in
+      Ok (spaces, not @@ Spaces.is_empty spaces) in
   let* ogre = match ogre with
     | None -> Ok None
     | Some path -> match Ogre.Doc.from_file path with

--- a/vibes-tools/tools/vibes-patch/lib/runner.ml
+++ b/vibes-tools/tools/vibes-patch/lib/runner.ml
@@ -9,6 +9,7 @@ module Log = Vibes_log.Stream
 module Asm = Vibes_as.Types.Assembly
 module Patch_info = Vibes_patch_info.Types
 module Spaces = Patch_info.Spaces
+module Json = Vibes_utils.Json
 
 let (let*) x f = Result.bind x ~f
 
@@ -39,6 +40,7 @@ let parse_asms
   aux [] asm_filepaths
 
 let run
+    ?(ogre : string option = None)
     ?(patch_spaces : string option = None)
     ~(target : string)
     ~(language : string)
@@ -52,12 +54,33 @@ let run
     patched_binary;
   let* target = CT.get_target target in
   let* language = CT.get_language language in
+  let had_spaces = Option.is_some patch_spaces in
   let* patch_spaces = match patch_spaces with
     | Some path -> Spaces.from_file path
     | None -> Ok Spaces.empty in
+  let* ogre = match ogre with
+    | None -> Ok None
+    | Some path -> match Ogre.Doc.from_file path with
+      | Error err -> Error (Errors.Invalid_ogre (Error.to_string_hum err))
+      | Ok ogre -> Ok (Some ogre) in
   let* asms = parse_asms asm_filepaths in
-  let* _, spaces = Patcher.patch target language asms
-      ~binary ~patched_binary ~patch_spaces in
-  if not @@ Spaces.is_empty spaces then
-    Log.send "Remaining patch spaces:\n%a" Spaces.pp spaces;
+  let* res = Patcher.patch target language asms
+      ~binary ~patched_binary ~patch_spaces ~ogre in
+  let* () =
+    if Spaces.is_empty res.spaces then
+      Ok (if had_spaces then Log.send "No patch spaces remaining")
+    else
+      let path = Format.sprintf "%s-patch-spaces.json" patched_binary in
+      let pp = Json.pp ~yojson_of_t:Spaces.yojson_of_t in
+      let data = Format.asprintf "%a" pp res.spaces in
+      Log.send "Remaining patch spaces:\n%a" Spaces.pp res.spaces;
+      Log.send "Writing to %s" path;
+      Files.write_or_error data path in
+  let* () = match res.new_ogre with
+    | None -> Ok ()
+    | Some ogre ->
+      let path = Format.sprintf "%s.ogre" patched_binary in
+      let data = Ogre.Doc.to_string ogre in
+      Log.send "Writing new OGRE specification to %s" path;
+      Files.write_or_error data path in
   Ok ()

--- a/vibes-tools/tools/vibes-patch/lib/runner.mli
+++ b/vibes-tools/tools/vibes-patch/lib/runner.mli
@@ -2,6 +2,7 @@ open Bap_core_theory
 
 (** Attempts to patch the binary with the provided assembly code. *)
 val run :
+  ?ogre:string option ->
   ?patch_spaces:string option ->
   target:string ->
   language:string ->

--- a/vibes-tools/tools/vibes-patch/lib/types.ml
+++ b/vibes-tools/tools/vibes-patch/lib/types.ml
@@ -4,7 +4,7 @@ module Asm = Vibes_as.Types.Assembly
 
 module type Toolchain = sig
 
-  val assemble : Asm.t -> Theory.language -> (string, KB.conflict) result
+  val assemble : Asm.t -> Theory.language -> (string * int, KB.conflict) result
   val to_binary : string -> (string, KB.conflict) result
 
 end

--- a/vibes-tools/tools/vibes-patch/lib/types.mli
+++ b/vibes-tools/tools/vibes-patch/lib/types.mli
@@ -5,8 +5,9 @@ module Asm = Vibes_as.Types.Assembly
 (** Abstraction behild the toolchain in order to perform the patch. *)
 module type Toolchain = sig
 
-  (** Assembles the program and returns the path to the object file. *)
-  val assemble : Asm.t -> Theory.language -> (string, KB.conflict) result
+  (** Assembles the program and returns the path to the object file,
+      along with the number of bytes of inline data that was discovered. *)
+  val assemble : Asm.t -> Theory.language -> (string * int, KB.conflict) result
 
   (** Obtains the raw binary code of the object file. *)
   val to_binary : string -> (string, KB.conflict) result

--- a/vibes-tools/tools/vibes-patch/lib/utils.ml
+++ b/vibes-tools/tools/vibes-patch/lib/utils.ml
@@ -4,9 +4,15 @@ open Bap.Std
 module S = Image.Scheme
 
 type region = {
+  addr   : int64;
+  size   : int64;
+  offset : int64;
+}
+
+type named_region = {
   addr : int64;
   size : int64;
-  offset : int64;
+  name : string;
 }
 
 (* Search for the largest code region containing the address. *)
@@ -14,13 +20,13 @@ let find_code_region
     (loc : int64)
     (spec : Ogre.doc) : region option =
   let compare (_, s1, _) (_, s2, _) = Int64.compare s2 s1 in
-  Ogre.foreach Ogre.Query.(begin
+  Ogre.collect Ogre.Query.(begin
       let open S in
       let addr = code_region.(addr) in
       let size = code_region.(size) in
       select ~where:(addr <= int loc && int loc < addr + size)
         (from code_region)
-    end) ~f:Fn.id |> Fn.flip Ogre.eval spec |> Or_error.ok |>
+    end) |> Fn.flip Ogre.eval spec |> Or_error.ok |>
   Option.map ~f:Seq.to_list |>
   Option.map ~f:(List.sort ~compare) |>
   Option.bind ~f:List.hd |>
@@ -31,17 +37,37 @@ let find_mapped_region
     (loc : int64)
     (spec : Ogre.doc) : region option =
   let compare {S.size=s1;_} {S.size=s2;_} = Int64.compare s2 s1 in
-  Ogre.foreach Ogre.Query.(begin
+  Ogre.collect Ogre.Query.(begin
       let open Image.Scheme in
       let addr = mapped.(addr) in
       let size = mapped.(size) in
       select ~where:(addr <= int loc && int loc < addr + size)
         (from mapped)
-    end) ~f:Fn.id |> Fn.flip Ogre.eval spec |> Or_error.ok |>
+    end) |> Fn.flip Ogre.eval spec |> Or_error.ok |>
   Option.map ~f:Seq.to_list |>
   Option.map ~f:(List.sort ~compare) |>
   Option.bind ~f:List.hd |>
   Option.map ~f:(fun {S.addr; size; info=offset} -> {addr; size; offset})
+
+(* Search for the largest named region containing the address. *)
+let find_named_region (loc : int64) (spec : Ogre.doc) : named_region option =
+  let compare {S.size=s1;_} {S.size=s2;_} = Int64.compare s2 s1 in
+  Ogre.collect Ogre.Query.(begin
+      let open S in
+      let addr = named_region.(addr) in
+      let size = named_region.(size) in
+      select ~where:(addr <= int loc && int loc < addr + size)
+        (from named_region)
+    end) |> Fn.flip Ogre.eval spec |> Or_error.ok |>
+  Option.map ~f:Seq.to_list |>
+  Option.map ~f:(List.sort ~compare) |>
+  Option.bind ~f:List.hd |>
+  Option.map ~f:(fun {S.addr; size; info=name} -> {addr; size; name})
+
+(* Find the name of the symbol for the address. *)
+let find_named_symbol (loc : int64) (spec : Ogre.doc) : string option =
+  Ogre.require S.named_symbol ~that:(fun (addr, _) -> Int64.(addr = loc)) |>
+  Fn.flip Ogre.eval spec |> Or_error.ok |> Option.map ~f:snd
 
 let addr_to_offset (addr : int64) (region : region) : int64 =
   Int64.(addr - region.addr + region.offset)

--- a/vibes-tools/tools/vibes-patch/lib/utils.mli
+++ b/vibes-tools/tools/vibes-patch/lib/utils.mli
@@ -1,8 +1,15 @@
-(** A region in the binary. *)
+(** A region in the binary with a file offset. *)
 type region = {
+  addr   : int64;
+  size   : int64;
+  offset : int64;
+}
+
+(** A region in the binary with a name. *)
+type named_region = {
   addr : int64;
   size : int64;
-  offset : int64;
+  name : string;
 }
 
 (** [find_code_region addr spec] looks up the code region in [spec] that
@@ -12,6 +19,14 @@ val find_code_region : int64 -> Ogre.doc -> region option
 (** [find_mapped_region addr spec] looks up the mapped region in [spec] that
     contains [addr]. *)
 val find_mapped_region : int64 -> Ogre.doc -> region option
+
+(** [find_named_region addr spec] looks up the named region in [spec] that
+    contains [addr]. *)
+val find_named_region : int64 -> Ogre.doc -> named_region option
+
+(** [find_named_symbol addr spec] looks up the named symbol in [spec] that
+    has the address [addr]. *)
+val find_named_symbol : int64 -> Ogre.doc -> string option
 
 (** Converts a virtual address into a file offset. Assumes that the address
     is contained within the region. *)


### PR DESCRIPTION
When we place the patches in the binary, we may encounter the following scenarios:

1. We used an external patch space (which may or may not have previously existed).
2. The patch contains some inline data.

In either case, the OGRE file may not have this information, which is bad for when we want to do verification. Previously, this would be done manually, but obviously it's not a great user experience. This PR makes it so that we can extend the existing OGRE specification (if the user provided it to us) with this information, automatically.