### PR TITLE
Refactor C frontend again

### DIFF
--- a/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
@@ -1,0 +1,244 @@
+(* This is adapted from BAP's FrontC parser plugin. *)
+
+open Core
+(* open Bap.Std *)
+open Bap_c.Std
+
+let int (size : Cabs.size) (sign : Cabs.sign) : C.Type.basic = 
+  match size, sign with
+  | NO_SIZE,   (NO_SIGN | SIGNED) -> `sint
+  | SHORT,     (NO_SIGN | SIGNED) -> `sshort
+  | LONG,      (NO_SIGN | SIGNED) -> `slong
+  | LONG_LONG, (NO_SIGN | SIGNED) -> `slong_long
+  | NO_SIZE,   UNSIGNED           -> `uint
+  | SHORT,     UNSIGNED           -> `ushort
+  | LONG,      UNSIGNED           -> `ulong
+  | LONG_LONG, UNSIGNED           -> `ulong_long
+
+let char : Cabs.sign -> C.Type.basic = function
+  | NO_SIGN  -> `char
+  | SIGNED   -> `schar
+  | UNSIGNED -> `uchar
+
+let cv : unit C.Type.qualifier = {
+  const    = false;
+  volatile = false;
+  restrict = ();
+}
+
+let cvr : bool C.Type.qualifier = {
+  cv with restrict = false;
+}
+
+let restricted (cvr : _ C.Type.qualifier) : bool C.Type.qualifier = {
+  cvr with restrict = true;
+}
+
+let spec (qualifier : 'a) (t : 'b) : ('a, 'b) C.Type.spec = {
+  t;
+  attrs = [];
+  qualifier;
+}
+
+let restrict (t : C.Type.t) : C.Type.t = `Pointer (spec (restricted cvr) t)
+
+let size : Cabs.expression -> int option = function
+  | CONSTANT CONST_INT s -> Some (Int.of_string s)
+  | _ -> None
+
+let enum
+    (_name : string)
+    (fields : (string * int64 option) list) : C.Type.t =
+  C.Type.basic (`enum fields)
+
+let name_groups : Cabs.name_group list -> 'a list =
+  List.concat_map ~f:(fun (_, _, ns) ->
+      List.map ns ~f:(fun (n, t, attrs, _) -> n, t, attrs))
+
+let single_names : Cabs.single_name list -> 'a list =
+  List.map ~f:(fun (_, _, (n, t, attrs, _)) -> n, t, attrs)
+
+let rec gnu_attr : Cabs.gnu_attr -> C.Type.attr option = function
+  | GNU_NONE -> None
+  | GNU_CALL (name, args) ->
+    Some C.Type.Attr.{name; args = gnu_attrs_args args}
+  | GNU_ID s -> Some C.Type.Attr.{name = s; args = []}
+  | GNU_CST _ | GNU_EXTENSION | GNU_INLINE | GNU_TYPE_ARG _ -> None
+
+and gnu_attrs_args : Cabs.gnu_attr list -> string list =
+  List.filter_map ~f:(fun (a : Cabs.gnu_attr) -> match a with
+      | GNU_ID s
+      | GNU_CST
+          (CONST_INT s | CONST_FLOAT s | CONST_CHAR s | CONST_STRING s) ->
+        Some s
+      | _ -> None)
+
+let gnu_attrs : Cabs.gnu_attr list -> C.Type.attr list =
+  List.filter_map ~f:gnu_attr
+
+let with_attrs (attrs : C.Type.attr list) : C.Type.t -> C.Type.t =
+  let add t = C.Type.Spec.{t with attrs = t.attrs @ attrs} in
+  function
+  | `Void        -> `Void
+  | `Basic t     -> `Basic (add t)
+  | `Pointer t   -> `Pointer (add t)
+  | `Array t     -> `Array (add t)
+  | `Structure t -> `Structure (add t)
+  | `Union t     -> `Union (add t)
+  | `Function t  -> `Function (add t)
+
+type ('a, 'b) qs = ('a C.Type.qualifier, 'b) C.Type.spec
+
+type qualifier = {
+  apply : 'a 'b. ('a, 'b) qs -> ('a, 'b) qs;
+}
+
+let const : qualifier = {
+  apply = fun t -> C.Type.Spec.{
+      t with qualifier = C.Type.Qualifier.{
+      t.qualifier with const = true}
+    }
+}
+
+let volatile : qualifier = {
+  apply = fun t -> C.Type.Spec.{
+      t with qualifier = C.Type.Qualifier.{
+      t.qualifier with volatile = true}
+    }
+}
+
+let rec qualify (f : qualifier) : C.Type.t -> C.Type.t = function
+  | `Basic t -> `Basic (f.apply t)
+  | `Pointer t -> `Pointer (f.apply t)
+  | `Structure s -> `Structure C.Type.Spec.{
+      s with
+      t = C.Type.Compound.{
+          s.t with
+          fields = List.map s.t.fields ~f:(fun (n, t) -> n, qualify f t)
+        }
+    }
+  | x -> x
+
+type gamma = string -> C.Type.t
+
+type tag = {
+  lookup : 'a. (string -> 'a list -> C.Type.t) -> string -> C.Type.t;
+}
+
+let ctype (gamma : gamma) (tag : tag) (t : Cabs.base_type) : C.Type.t =
+  let rec ctype : Cabs.base_type -> C.Type.t = function
+    | NO_TYPE | TYPE_LINE _ | OLD_PROTO _ | BITFIELD _
+    | BUILTIN_TYPE _ | VOID -> `Void
+    | BOOL -> C.Type.basic `bool
+    | CHAR sign -> C.Type.basic @@ char sign
+    | INT (size, sign) -> C.Type.basic @@ int size sign
+    | FLOAT _ -> C.Type.basic `float
+    | DOUBLE long -> C.Type.basic @@ if long then `long_double else `double
+    | COMPLEX_FLOAT -> C.Type.basic `cfloat
+    | COMPLEX_DOUBLE -> C.Type.basic `cdouble
+    | COMPLEX_LONG_DOUBLE -> C.Type.basic `clong_double
+    | PTR t -> C.Type.pointer @@ ctype t
+    | RESTRICT_PTR t -> restrict @@ ctype t
+    | ARRAY (et, ice) -> C.Type.array ?size:(size ice) @@ ctype et
+    | STRUCT (n, []) -> tag.lookup C.Type.structure n
+    | UNION (n, []) -> tag.lookup C.Type.union n
+    | ENUM (n, []) -> tag.lookup enum n
+    | STRUCT (n, fs) -> C.Type.structure n @@ fields @@ name_groups fs
+    | UNION (n, fs) -> C.Type.union n @@ fields @@ name_groups fs
+    | PROTO (r, args, variadic) ->
+      C.Type.function_ ~variadic ~return:(ctype r) @@
+      fields @@ single_names args
+    | NAMED_TYPE name -> gamma name
+    | ENUM (name, fs) -> enum name @@ enum_items name fs
+    | CONST t -> qualify const @@ ctype t
+    | VOLATILE t -> qualify volatile @@ ctype t
+    | GNU_TYPE (a, t) -> with_attrs (gnu_attrs a) @@ ctype t
+  and enum_items _ : Cabs.enum_item list -> (string * int64 option) list =
+    List.map ~f:(fun (name, exp) -> match (exp : Cabs.expression) with
+        | CONSTANT (CONST_INT x) ->
+          name, Option.try_with @@ fun () -> Int64.of_string x
+        | _ -> name, None)
+  and fields xs = List.map xs ~f:(fun (name, t, a) ->
+      name, with_attrs (gnu_attrs a) @@ ctype t) in
+  ctype t
+
+module To_cabs = struct
+
+  let rec go : C.Type.t -> Cabs.base_type = function
+    | `Void -> VOID
+    | `Basic {C.Type.Spec.qualifier; t; _} ->
+      apply_cv_qualifier (basic t) qualifier
+    | `Pointer {C.Type.Spec.qualifier; t; _} ->
+      apply_cvr_qualifier (go t) qualifier
+    | `Array {C.Type.Spec.qualifier; t; _} ->
+      apply_cvr_qualifier (array t) qualifier
+    | `Structure {C.Type.Spec.t; _} -> structure t
+    | `Union {C.Type.Spec.t; _} -> union t
+    | `Function {C.Type.Spec.t; _} -> func t
+
+  and apply_cv_qualifier
+      (t : Cabs.base_type)
+      (q : C.Type.cv C.Type.qualifier) : Cabs.base_type =
+    let t = if q.const then Cabs.CONST t else t in
+    let t = if q.volatile then Cabs.VOLATILE t else t in
+    t
+
+  and apply_cvr_qualifier
+      (t : Cabs.base_type)
+      (q : C.Type.cvr C.Type.qualifier) : Cabs.base_type =
+    let t = if q.const then Cabs.CONST t else t in
+    let t = if q.volatile then Cabs.VOLATILE t else t in
+    let t = if q.restrict then Cabs.RESTRICT_PTR t else t in
+    t
+
+  and basic : C.Type.basic -> Cabs.base_type = function
+    | `bool         -> BOOL
+    | `char         -> CHAR NO_SIGN
+    | `schar        -> CHAR SIGNED
+    | `uchar        -> CHAR UNSIGNED
+    | `sshort       -> INT (SHORT, SIGNED)
+    | `ushort       -> INT (SHORT, UNSIGNED)
+    | `sint         -> INT (NO_SIZE, SIGNED)
+    | `uint         -> INT (NO_SIZE, UNSIGNED)
+    | `slong        -> INT (LONG, SIGNED)
+    | `ulong        -> INT (LONG, UNSIGNED)
+    | `slong_long   -> INT (LONG_LONG, SIGNED)
+    | `ulong_long   -> INT (LONG_LONG, UNSIGNED)
+    | `float        -> FLOAT false
+    | `double       -> DOUBLE false
+    | `long_double  -> DOUBLE true
+    | `cfloat       -> COMPLEX_FLOAT
+    | `cdouble      -> COMPLEX_DOUBLE
+    | `clong_double -> COMPLEX_LONG_DOUBLE
+    | `enum items   ->
+      let items = List.map items ~f:(function
+          | name, None -> name, Cabs.NOTHING
+          | name, Some value ->
+            name, CONSTANT (CONST_INT (Int64.to_string value))) in
+      ENUM ("", items)
+
+  and array (a : C.Type.array) : Cabs.base_type =
+    let e = go a.element in
+    let s = match a.size with
+      | None -> Cabs.NOTHING
+      | Some s -> CONSTANT (CONST_INT (Int.to_string s)) in
+    ARRAY (e, s)
+
+  and structure (c : C.Type.compound) : Cabs.base_type =
+    STRUCT (c.name, List.map c.fields ~f:field)
+
+  and union (c : C.Type.compound) : Cabs.base_type =
+    UNION (c.name, List.map c.fields ~f:field)
+
+  and field ((name, t) : string * C.Type.t) : Cabs.name_group =
+    let t = go t in
+    t, NO_STORAGE, [name, t, [], NOTHING]
+
+  and func (p : C.Type.proto) : Cabs.base_type =
+    let r = go p.return in
+    let args = List.map p.args ~f:(fun (name, t) ->
+        let t = go t in
+        t, Cabs.NO_STORAGE, (name, t, [], Cabs.NOTHING)) in
+    PROTO (r, args, p.variadic)
+
+end

--- a/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
@@ -1,7 +1,6 @@
 (* This is adapted from BAP's FrontC parser plugin. *)
 
 open Core
-(* open Bap.Std *)
 open Bap_c.Std
 
 let int (size : Cabs.size) (sign : Cabs.sign) : C.Type.basic = 

--- a/vibes-tools/tools/vibes-c-toolkit/lib/ctype.mli
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/ctype.mli
@@ -1,0 +1,20 @@
+open Bap_c.Std
+
+(** Lookup for named types. *)
+type gamma = string -> C.Type.t
+
+(** Lookup for structures and unions. *)
+type tag = {
+  lookup : 'a. (string -> 'a list -> C.Type.t) -> string -> C.Type.t;
+}
+
+(** Converts a FrontC type to a BAP C type. *)
+val ctype : gamma -> tag -> Cabs.base_type -> C.Type.t
+
+(** Conversion back to the FrontC representation. *)
+module To_cabs : sig
+
+  (** Convert a BAP C type to a FrontC type. *)
+  val go : C.Type.t -> Cabs.base_type
+
+end

--- a/vibes-tools/tools/vibes-c-toolkit/lib/errors.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/errors.ml
@@ -1,10 +1,12 @@
 open Bap_core_theory
 
 type KB.conflict +=
+  | Parse_c of string
   | Patch_c of string
   | Core_c of string
 
 let printer : KB.conflict -> string option = function
+  | Parse_c s -> Some s
   | Patch_c s -> Some s
   | Core_c s -> Some s
   | _ -> None

--- a/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.ml
@@ -1,46 +1,101 @@
 open Core
+open Bap_core_theory
+
+module Files = Vibes_utils.Files
+module Proc = Vibes_utils.Proc
+module Log = Vibes_log.Stream
+
+let (let*) x f = Result.bind x ~f
 
 let dummy_decl : string = "void dummy()"
-let dummy_len : int = String.length dummy_decl + 1
 
-let file_pos (input : string) (lexbuf : Lexing.lexbuf) : string =
+let err (msg : string) : (_, KB.conflict) result =
+  Error (Errors.Parse_c msg)
+
+type builtin = {
+  name   : string;
+  size   : int;
+  signed : bool;
+}
+
+let builtin_typenames : builtin list = [
+  {name = "int8_t";   size = 8;  signed = true};
+  {name = "uint8_t";  size = 8;  signed = false};
+  {name = "int16_t";  size = 16; signed = true};
+  {name = "uint16_t"; size = 16; signed = false};
+  {name = "int32_t";  size = 32; signed = true};
+  {name = "uint32_t"; size = 32; signed = false};
+  {name = "int64_t";  size = 64; signed = true};
+  {name = "uint64_t"; size = 64; signed = false};
+]
+
+type pos = {
+  lineno : int;
+  column : int;
+  line   : string option;
+}
+
+(* Find the position in the input stream where the parser failed. *)
+let file_pos (ic : In_channel.t) (lexbuf : Lexing.lexbuf) : pos =
   let open Lexing in
+  In_channel.seek ic 0L;
+  let input = In_channel.input_all ic in
   let pos = lexbuf.lex_curr_p in
   let l, c =
     (* The lexer seems to ignore the newlines when updating the
        position in the buffer, so we will do it manually. *)
-    let c = pos.pos_cnum - pos.pos_bol + 1 in
-    let init = 1, 1, c and finish (l, c, _) = l, c in
+    let r = pos.pos_cnum - pos.pos_bol + 1 in
+    let init = 1, 1, r and finish (l, c, _) = l, c in
     String.fold_until input ~init ~finish ~f:(fun (l, c, r) x ->
         let l, c, r = match x with
-          | '\r' -> l, 1, r
-          | '\n' -> l + 1, 1, r
-          | _ -> l, c + 1, r - 1 in
-        if r <= 1 then Stop (l, c)
-        else Continue (l, c, r)) in
-  (* First line should account for the dummy declaration. *)
-  let c = if l = 1 then c - dummy_len else c in
-  Format.sprintf "line %d, column %d" l c
+          | '\r' -> l,     1,     r - 1
+          | '\n' -> l + 1, 1,     r - 1
+          | _    -> l,     c + 1, r - 1 in
+        if r <= 1 then Stop (l, c - 1) else Continue (l, c, r)) in
+  let line = List.nth (String.split_lines input) (l - 1) in
+  {lineno = l; column = c; line}
 
-(* Parses a string into a Cabs.file *)
-let parse_c_file (input : string) : (Cabs.file, string) result =
-  let lexbuf = Lexing.from_string input ~with_positions:true in
-  Clexer.init_lexicon ();
-  match Cparser.file Clexer.initial lexbuf with
-  | exception exn ->
-    let msg =
-      Format.asprintf "%a: %s" Exn.pp exn @@
-      file_pos input lexbuf in
-    Error msg
-  | ast -> Ok ast
+let parse_c_file (filename : string) : (Cabs.file, KB.conflict) result =
+  In_channel.with_file filename ~f:(fun ic ->
+      let open Clexer in
+      init {
+        !current_handle with
+        h_in_channel = ic;
+        h_file_name = filename;
+        h_out_channel = stderr;
+      };
+      init_lexicon ();
+      List.iter builtin_typenames ~f:(fun {name; _} -> add_type name);
+      let lexbuf = Lexing.from_function @@ get_buffer current_handle in
+      match Cparser.file initial lexbuf with
+      | exception _ ->
+        let p = file_pos ic lexbuf in
+        begin match p.line with
+          | None ->
+            err @@ Format.asprintf "Parser error at %s:%d:%d"
+              filename p.lineno p.column
+          | Some line ->
+            (* Have an arrow point to the column of the offending line. *)
+            let arrow = String.init p.column ~f:(fun i ->
+                if i = p.column - 1 then '^' else ' ') in
+            err @@ Format.asprintf "Parser error at %s:%d:%d:\n%s\n%s"
+              filename p.lineno p.column line arrow
+        end
+      | ast -> Ok ast)
 
-(* Parses a sequence of C statements (a body) by wrapping it in a
-   dummy function, parsing that as a file and then extracting the
-   first def from the result *)
-let parse (input : string) : (Cabs.definition, string) result =
-  let p = Printf.sprintf "%s{%s}" dummy_decl input in
-  match parse_c_file p with
+let preprocess (input : string) : (string, KB.conflict) result =
+  let p = Printf.sprintf "%s{\n%s}" dummy_decl input in
+  let filename = Stdlib.Filename.temp_file "vibes" ".c" in
+  let* () = Files.write_or_error p filename in
+  Log.send "Running the C preprocessor";
+  let filename_cpp = Stdlib.Filename.temp_file "vibes-preprocessed" ".c" in
+  let* _ = Proc.run "cpp" [filename; "-P"; "-o"; filename_cpp] in
+  Ok filename_cpp
+
+let parse (input : string) : (Cabs.definition, KB.conflict) result =
+  let* filename = preprocess input in
+  match parse_c_file filename with
   | Ok [def] -> Ok def
-  | Ok [] -> Error "No definitions parsed"
-  | Ok _ -> Error "More than one definition parsed, expected only one"
+  | Ok [] -> err "No definitions parsed"
+  | Ok _ -> err "More than one definition parsed, expected only one"
   | Error _ as err -> err

--- a/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.mli
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/parse_c.mli
@@ -1,3 +1,16 @@
+open Bap_core_theory
+
+(** A builtin type. *)
+type builtin = {
+  name   : string;
+  size   : int;
+  signed : bool;
+}
+
+(** A list of typenames that the C lexer is made aware of when
+    parsing. *)
+val builtin_typenames : builtin list
+
 (** [parse input] takes a single block of C source code and parses
     it into a single function definition if it is well-formed. *)
-val parse : string -> (Cabs.definition, string) result
+val parse : string -> (Cabs.definition, KB.conflict) result

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -926,6 +926,7 @@ module Main = struct
 
   end
 
+  (* Resolve the names of struct and union types. *)
   let resolver lookup = object(self)
     inherit [unit] C.Type.Mapper.base
 

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -984,11 +984,7 @@ module Main = struct
               fail msg) in
     let* () = update @@ fun env ->
       let resolve = (resolver @@ Map.find env.tags)#run in
-      let gamma =
-        String.Map.to_sequence env.gamma |>
-        Seq.map ~f:(fun (name, t) -> name, resolve t) |>
-        String.Map.of_sequence_exn in
-      {env with gamma} in
+      {env with gamma = Map.map env.gamma ~f:resolve} in
     let* inits = go_inits @@ List.rev inits in
     let* () = update @@ fun env -> {env with tenv = new_tenv} in
     let* s = go_statement stmt in

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -1273,10 +1273,12 @@ module Main = struct
           end
         | _ -> default () in
       match t with
+      | `Void when no_ptr ->
+        typ_error Cabs.(BINARY (b, lhs, rhs)) t
+          "Expected integral type"
       | `Void ->
-        let msg = if no_ptr then "Expected integral type"
-          else "Expected integral or pointer type" in
-        typ_error Cabs.(BINARY (b, lhs, rhs)) t msg
+        typ_error Cabs.(BINARY (b, lhs, rhs)) t
+          "Expected integral or pointer type"
       | (`Pointer _) as t when no_ptr ->
         typ_error Cabs.(BINARY (b, lhs, rhs)) t
           "Pointer type is not allowed"
@@ -1554,8 +1556,8 @@ module Main = struct
               Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e),
               Utils.print_c Cprint.print_statement Cabs.(COMPUTATION arg) in
             let msg = Format.asprintf
-                "Patch_c.go_call_args:\n\n%s\
-                 \n\nargument %s has type %a but type %a was \
+                "Patch_c.go_call_args:\n\n%s\n\n\
+                 argument %s has type %a but type %a was \
                  expected" s a C.Type.pp ta C.Type.pp t in
             fail msg)
     | Unequal_lengths ->

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.mli
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.mli
@@ -129,7 +129,11 @@ and stmt =
   | GOTO of string
 
 (** A scope where statements may occur under a typing environment. *)
-and body = tenv * stmt
+and body = {
+  tenv  : tenv;
+  stmt  : stmt;
+  label : string option;
+}
 
 (** A PatchC definition is a scoped statement. We also include the
     data model for sizing of integers. *)
@@ -138,6 +142,10 @@ type t = {
   csize : C.Size.base;
   body  : body;
 }
+
+(** Returns the set of labels defined in the program, or an error
+    if there was a duplicate label. *)
+val label_env : t -> (String.Set.t, KB.conflict) result
 
 module Exp : sig
 

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.mli
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.mli
@@ -36,12 +36,9 @@ type size = [`r8 | `r16 | `r32 | `r64]
 (** Subset of [Cabs.sign], where now signedness is explicit. *)
 type sign = SIGNED | UNSIGNED
 
-(** Subset of [Cabs.base_type] for types supported by VIBES. *)
-type typ =
-  | VOID
-  | INT of size * sign
-  | PTR of typ
-  | FUN of typ * typ list
+(** Same as BAP C's types. Not all are currently supported by
+    the compiler. *)
+type typ = C.Type.t
 
 (** Compares two types for equality. *)
 val equal_typ : typ -> typ -> bool
@@ -52,11 +49,8 @@ module Type : sig
 
   val equal : t -> t -> bool
 
-  (** Returns the size of the type in bits. *)
-  val size : Theory.target -> typ -> int
-
   (** Returns the signedness of the type. *)
-  val sign : typ -> sign option
+  val sign : Data_model.t -> typ -> sign
 
 end
 
@@ -140,8 +134,9 @@ and body = tenv * stmt
 (** A PatchC definition is a scoped statement. We also include the
     data model for sizing of integers. *)
 type t = {
-  data : Data_model.t;
-  body: body;
+  data  : Data_model.t;
+  csize : C.Size.base;
+  body  : body;
 }
 
 module Exp : sig
@@ -151,11 +146,11 @@ module Exp : sig
   val to_string : t -> string
 
   (** Returns the type embedded in an expression. *)
-  val typeof : t -> typ
+  val typeof : Data_model.t -> t -> typ
 
   (** Force an expression to carry a new type. This operation is
       unsafe unless you know what you're doing! *)
-  val coerce_type : t -> typ -> t
+  val coerce_type : Data_model.t -> C.Size.base -> t -> typ -> t
 
 end
 

--- a/vibes-tools/tools/vibes-parse/lib/errors.ml
+++ b/vibes-tools/tools/vibes-parse/lib/errors.ml
@@ -2,14 +2,12 @@ open Bap_core_theory
 
 type KB.conflict +=
   | No_patch_code of string
-  | Invalid_C of string
   | Invalid_sexp of string
   | Unknown_target of string
 
 let printer (e : KB.conflict) : string option =
   match e with
   | No_patch_code s -> Some s
-  | Invalid_C s -> Some s
   | Invalid_sexp s -> Some s
   | Unknown_target s -> Some s
   | _ -> None

--- a/vibes-tools/tools/vibes-parse/lib/runner.ml
+++ b/vibes-tools/tools/vibes-parse/lib/runner.ml
@@ -17,7 +17,7 @@ open KB.Syntax
 let parse_c_code (raw_code : string) : (Types.ast, KB.conflict) result =
   Log.send "Parsing C code";
   match C_toolkit.Parse_c.parse raw_code with
-  | Error msg -> Error (Errors.Invalid_C msg)
+  | Error _ as e -> e
   | Ok ast as a ->
     let s = C_toolkit.C_utils.print_c Cprint.print_def ast in
     Log.send "Parsed:\n%s" s;


### PR DESCRIPTION
Addresses #173. To better support the C type system we re-use the code from the `Bap_c` module, which required a bit of refactoring.

Also, the error messages from the C parser are improved.