### PR TITLE
Minimal support for `struct` types

### DIFF
--- a/vibes-tools/tools/vibes-c-toolkit/lib/core_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/core_c.ml
@@ -189,58 +189,30 @@ module Make(CT : Theory.Core) = struct
       lift_binop op
         (ty_of_base_type info ty_a)
         (ty_of_base_type info ty_b) in
+    let sa = Patch_c.Type.sign info.data ty_a in
+    let sb = Patch_c.Type.sign info.data ty_b in
+    let signed uop sop = match sa, sb with
+      | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv uop)
+      | SIGNED, SIGNED -> !!(lift_bitv sop) in
     match op with
-    | ADD -> !!(lift_bitv CT.add)
-    | SUB -> !!(lift_bitv CT.sub)
-    | MUL -> !!(lift_bitv CT.mul)
-    | DIV -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.div)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.sdiv)
-      end
-    | MOD -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.modulo)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.smodulo)
-      end
+    | ADD  -> !!(lift_bitv CT.add)
+    | SUB  -> !!(lift_bitv CT.sub)
+    | MUL  -> !!(lift_bitv CT.mul)
+    | DIV  -> signed CT.div CT.sdiv
+    | MOD  -> signed CT.modulo CT.smodulo
     | LAND -> !!(lift_bitv CT.logand)
-    | LOR -> !!(lift_bitv CT.logor)
-    | XOR -> !!(lift_bitv CT.logxor)
-    | SHL -> !!(lift_bitv CT.lshift)
-    | SHR  -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | SIGNED, _ -> !!(lift_bitv CT.arshift)
-        | UNSIGNED, _ -> !!(lift_bitv CT.rshift)
-      end
-    | EQ  -> !!(lift_bitv CT.eq)
-    | NE  -> !!(lift_bitv CT.neq)
-    | LT -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.ult)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.slt)
-      end
-    | GT -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.ugt)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.sgt)
-      end
-    | LE -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.ule)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.sle)
-      end
-    | GE -> begin
-        match Patch_c.Type.sign info.data ty_a,
-              Patch_c.Type.sign info.data ty_b with
-        | UNSIGNED, _ | _, UNSIGNED -> !!(lift_bitv CT.uge)
-        | SIGNED, SIGNED -> !!(lift_bitv CT.sge)
-      end
+    | LOR  -> !!(lift_bitv CT.logor)
+    | XOR  -> !!(lift_bitv CT.logxor)
+    | SHL  -> !!(lift_bitv CT.lshift)
+    | EQ   -> !!(lift_bitv CT.eq)
+    | NE   -> !!(lift_bitv CT.neq)
+    | LT   -> signed CT.ult CT.slt
+    | GT   -> signed CT.ugt CT.sgt
+    | LE   -> signed CT.ule CT.sle
+    | GE   -> signed CT.uge CT.sge
+    | SHR  -> match sa, sb with
+      | SIGNED,   _ -> !!(lift_bitv CT.arshift)
+      | UNSIGNED, _ -> !!(lift_bitv CT.rshift)
 
   type 'a bitv = 'a T.bitv
 

--- a/vibes-tools/tools/vibes-c-toolkit/lib/core_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/core_c.ml
@@ -277,8 +277,10 @@ module Make(CT : Theory.Core) = struct
   let addr_of_var (info : _ interp_info) (v : string) : unit pure =
     match Hvar.find v info.hvars with
     | None ->
-      fail @@ sprintf "laddr_of_var: missing higher var %s for ADDROF \
-                       expression, storage classification is required" v
+      let msg = Format.sprintf
+          "addr_of_var: missing higher var %s for ADDROF \
+           expression, storage classification is required" v in
+      fail msg
     | Some {value; _} -> match value with
       | Hvar.(Memory (Frame (reg, off))) ->
         let* reg = try_mark_reg info reg in
@@ -290,8 +292,10 @@ module Make(CT : Theory.Core) = struct
         let+ a = CT.int info.word_sort (Word.to_bitvec addr) in
         T.Value.forget a
       | _ ->
-        fail @@ sprintf "addr_of_var: higher var %s for ADDROF expression \
-                         is not stored in a memory location." v
+        let msg = Format.sprintf
+            "addr_of_var: higher var %s for ADDROF expression \
+             is not stored in a memory location." v in
+        fail msg
 
   let rec expr_to_pure
       (info : _ interp_info)

--- a/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/ctype.ml
@@ -168,7 +168,7 @@ module To_cabs = struct
     | `Basic {C.Type.Spec.qualifier; t; _} ->
       apply_cv_qualifier (basic t) qualifier
     | `Pointer {C.Type.Spec.qualifier; t; _} ->
-      apply_cvr_qualifier (go t) qualifier
+      apply_cvr_qualifier (Cabs.PTR (go t)) qualifier
     | `Array {C.Type.Spec.qualifier; t; _} ->
       apply_cvr_qualifier (array t) qualifier
     | `Structure {C.Type.Spec.t; _} -> structure t

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -1201,8 +1201,8 @@ module Main = struct
           spre, Some e, spost
       end
     | Cabs.MEMBEROF (ptr, field) ->
-      let e = Cabs.MEMBEROFPTR (UNARY (ADDROF, ptr), field) in
-      go_expression e ~assign ~computation
+      let ptr = Cabs.UNARY (ADDROF, ptr) in
+      go_memberof ptr field
     | Cabs.MEMBEROFPTR (ptr, field) -> go_memberof ptr field
     | _ ->
       let s = Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e) in

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -38,12 +38,6 @@ module Data_model = struct
     | `LP32 | `ILP32 | `LLP64 -> 32
     | `ILP64 | `LP64 -> 64
 
-  (* Size of pointers. *)
-  let addr_size (data : t) : int = match data.sizes with
-    | #C.Data.model32 -> 32
-    | #C.Data.model64 -> 64
-  [@@warning "-32"]
-
 end
 
 module Size = struct
@@ -473,6 +467,23 @@ module Type = struct
       then Some (tl, r) else Some (tl, Exp.with_type data csize r tl)
     | _ -> None
 
+  let field_offset
+      (csize : C.Size.base)
+      (t : typ)
+      (name : string) : word option =
+    if C.Type.is_structure t then
+      match C.Abi.layout csize t with
+      | {layout = C.Data.Seq data} ->
+        let init = 0 and finish _ = None in
+        let width = csize#pointer |> Bap.Std.Size.in_bits in
+        List.fold_until data ~init ~finish ~f:(fun acc -> function
+            | Imm (_, Field (f, _)) when String.(name = f) -> Stop (Some acc)
+            | Imm (s, _) -> Continue (acc + s)
+            | _ -> Stop None) |>
+        Option.map ~f:(fun off -> Word.of_int (off lsr 3) ~width)
+      | _ -> None
+    else None
+
 end
 
 let to_string (prog : t) : string =
@@ -797,7 +808,10 @@ module Main = struct
       let* () = check_no_cvr "Pointer" t qualifier ~msg in
       check_no_attrs "Pointer" t attrs ~msg
     | `Array _ as t -> unsupported_typ "Array" t ~msg
-    | `Structure _ as t -> unsupported_typ "Structure" t ~msg
+    | `Structure {C.Type.Spec.t = compound; attrs; _} as t ->
+      let* () = Transl.List.iter compound.fields ~f:(fun (_, t) ->
+          check_supported_typ t ~msg) in
+      check_no_attrs "Structure" t attrs ~msg
     | `Union _ as t -> unsupported_typ "Union" t ~msg
     | `Function {C.Type.Spec.t = proto; _} as t when proto.variadic ->
       unsupported_typ "Variadic function" t ~msg
@@ -1184,6 +1198,10 @@ module Main = struct
           let e = UNARY (MEMOF, CAST (C.Type.pointer t, e), t) in
           spre, Some e, spost
       end
+    | Cabs.MEMBEROF (ptr, field) ->
+      let e = Cabs.MEMBEROFPTR (UNARY (ADDROF, ptr), field) in
+      go_expression e ~assign ~computation
+    | Cabs.MEMBEROFPTR (ptr, field) -> go_memberof ptr field
     | _ ->
       let s = Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e) in
       fail (
@@ -1759,6 +1777,59 @@ module Main = struct
       let msg = Format.asprintf
           "Patch_c.go_index: in expression:\n\n%s\n\nIndex operand \
            has type %a. Expected integer.\n" s C.Type.pp tidx in
+      fail msg
+
+  and go_memberof (ptr : Cabs.expression) (field : string) : eexp transl =
+    let exp = go_expression_strict "go_memberof" in
+    let* sptrpre, eptr, sptrpost = exp ptr in
+    let* {data; csize; _} = get () in
+    let tptr = Exp.typeof data eptr in
+    match tptr with
+    | `Pointer {C.Type.Spec.t; _} -> begin
+        match t with
+        | `Structure {C.Type.Spec.t = compound; _} -> begin
+            match Type.field_offset csize t field with
+            | Some off ->
+              let _, tfield =
+                List.find_exn compound.fields ~f:(fun (name, _) ->
+                    String.equal name field) in
+              let tfield' = C.Type.pointer tfield in
+              let tarith = int_typ data (csize#pointer :> size) UNSIGNED in
+              let eptr = Exp.with_type data csize eptr tarith in
+              let e =
+                UNARY (
+                  MEMOF,
+                  CAST (
+                    tfield',
+                    BINARY (
+                      ADD,
+                      eptr,
+                      CONST_INT (off, UNSIGNED),
+                      tarith)),
+                  tfield) in
+              return (sptrpre, Some e, sptrpost)
+            | None ->
+              let e = Cabs.(MEMBEROFPTR (ptr, field)) in
+              let s = Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e) in
+              let msg = Format.sprintf
+                  "Patch_c.go_memberof: in expression:\n\n%s\n\nstruct %s \
+                   has no such field %s\n" s compound.name field in
+              fail msg
+          end
+        | _ ->
+          let e = Cabs.(MEMBEROFPTR (ptr, field)) in
+          let s = Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e) in
+          let msg = Format.asprintf
+              "Patch_c.go_memberof: in expression:\n\n%s\n\nexpected \
+               struct, got %a\n" s C.Type.pp tptr in
+          fail msg
+      end
+    | _ ->
+      let e = Cabs.(MEMBEROFPTR (ptr, field)) in
+      let s = Utils.print_c Cprint.print_statement Cabs.(COMPUTATION e) in
+      let msg = Format.asprintf
+          "Patch_c.go_memberof: in expression:\n\n%s\n\nexpected \
+           pointer, got %a\n" s C.Type.pp tptr in
       fail msg
 
   (* Translate a statement. *)

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -1201,6 +1201,9 @@ module Main = struct
           spre, Some e, spost
       end
     | Cabs.MEMBEROF (ptr, field) ->
+      (* TODO: if the entire struct fits inside of a register, then can we
+         optimize this to just use bitwise operations to extract the
+         corresponding element? *)
       let ptr = Cabs.UNARY (ADDROF, ptr) in
       go_memberof ptr field
     | Cabs.MEMBEROFPTR (ptr, field) -> go_memberof ptr field

--- a/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/patch_c.ml
@@ -259,7 +259,9 @@ module Cabs = struct
       (* We can use increment inside of a memory operation, while
          still having the expression result in an l-value. *)
       | Cabs.(UNARY (MEMOF, e))
-      | Cabs.(INDEX (e, _)) -> aux e ~mem:true
+      | Cabs.(INDEX (e, _))
+      | Cabs.(MEMBEROF (e, _))
+      | Cabs.(MEMBEROFPTR (e, _)) -> aux e ~mem:true
       (* Operand of increment must be an l-value regardless of
          whether we're inside of a MEMOF or not. *)
       | Cabs.(UNARY (POSINCR, e))


### PR DESCRIPTION
It turns out that BAP indeed has done a lot of the heavy lifting for us (in particular with `Bap_c_abi.layout`). It doesn't take that much more work to support `struct`s in a minimal way.