### PR TITLE
Fixes for BAP dune

### DIFF
--- a/vibes-tools/tools/vibes-as/lib/dune
+++ b/vibes-tools/tools/vibes-as/lib/dune
@@ -6,6 +6,8 @@
  (flags -w -32)
  (libraries
    bap-core-theory
+   findlib.dynload
+   threads
    vibes-log
    vibes-constants
    vibes-utils

--- a/vibes-tools/tools/vibes-bir/lib/dune
+++ b/vibes-tools/tools/vibes-bir/lib/dune
@@ -2,8 +2,8 @@
  (name vibes_bir)
  (public_name vibes-bir)
  (libraries
+   bap-std
    findlib.dynload
-   bap
    vibes-constants
    vibes-log)
  (preprocess (pps ppx_compare ppx_sexp_conv ppx_bin_prot)))

--- a/vibes-tools/tools/vibes-bir/lib/dune
+++ b/vibes-tools/tools/vibes-bir/lib/dune
@@ -2,7 +2,7 @@
  (name vibes_bir)
  (public_name vibes-bir)
  (libraries
-   bap-std
+   bap
    findlib.dynload
    vibes-constants
    vibes-log)

--- a/vibes-tools/tools/vibes-c-toolkit/lib/dune
+++ b/vibes-tools/tools/vibes-c-toolkit/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-c-toolkit)
  (libraries
    findlib.dynload
-   bap
    bap-arm
    FrontC
    core_unix.sys_unix

--- a/vibes-tools/tools/vibes-higher-vars/lib/dune
+++ b/vibes-tools/tools/vibes-higher-vars/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-higher-vars)
  (libraries
    findlib.dynload
-   bap
    vibes-log
    vibes-utils
    vibes-bir)

--- a/vibes-tools/tools/vibes-init/lib/dune
+++ b/vibes-tools/tools/vibes-init/lib/dune
@@ -4,6 +4,8 @@
  (flags -w -32)
  (libraries
    bap-core-theory
+   findlib.dynload
+   threads
    vibes-log
    vibes-constants
    vibes-patch-info

--- a/vibes-tools/tools/vibes-init/lib/runner.ml
+++ b/vibes-tools/tools/vibes-init/lib/runner.ml
@@ -25,9 +25,9 @@ let run
   let* language = match language with
     | Some language -> Result.(CT.get_language language >>| Option.some)
     | None -> Ok None in
-  let* t = Types.create ~language ~patch_names ~ogre
-      ~model:model_filepath ~binary ~patched_binary
-      ~spaces:Inputs.default_patch_spaces in
+  let* t = Types.create ()
+      ~language ~patch_names ~ogre ~binary ~patched_binary
+      ~model:model_filepath ~spaces:Inputs.default_patch_spaces in
   Log.send "Generating template files";
   let* () = Types.generate_files t in
   Log.send "Generating Makefile";

--- a/vibes-tools/tools/vibes-init/lib/types.ml
+++ b/vibes-tools/tools/vibes-init/lib/types.ml
@@ -108,7 +108,8 @@ let create
     ~(model : string)
     ~(binary : string)
     ~(patched_binary : string)
-    ~(spaces : string) : (t, KB.conflict) result =
+    ~(spaces : string)
+    () : (t, KB.conflict) result =
   let (let+) x f = Result.map x ~f in
   let+ target, language = infer_target_and_lang binary ~language in {
     target;

--- a/vibes-tools/tools/vibes-init/lib/types.mli
+++ b/vibes-tools/tools/vibes-init/lib/types.mli
@@ -33,7 +33,7 @@ val create :
   binary:string ->
   patched_binary:string ->
   spaces:string ->
-  (t, KB.conflict) result
+  unit -> (t, KB.conflict) result
 
 (** Pretty-prints the Makefile for running the pipeline. *)
 val pp_makefile : Format.formatter -> t -> unit

--- a/vibes-tools/tools/vibes-ir/lib/dune
+++ b/vibes-tools/tools/vibes-ir/lib/dune
@@ -2,7 +2,6 @@
  (name vibes_ir)
  (public_name vibes-ir)
  (libraries
-   bap
    vibes-utils
    vibes-constants)
  (preprocess (pps ppx_compare

--- a/vibes-tools/tools/vibes-linear-ssa/lib/dune
+++ b/vibes-tools/tools/vibes-linear-ssa/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-linear-ssa)
  (libraries
    findlib.dynload
-   bap
    core
    monads
    vibes-log

--- a/vibes-tools/tools/vibes-minizinc/lib/dune
+++ b/vibes-tools/tools/vibes-minizinc/lib/dune
@@ -2,7 +2,6 @@
  (name vibes_minizinc)
  (public_name vibes-minizinc)
  (libraries
-   bap
    bap-arm
    vibes-ir
    vibes-log

--- a/vibes-tools/tools/vibes-opt/lib/dune
+++ b/vibes-tools/tools/vibes-opt/lib/dune
@@ -3,6 +3,7 @@
  (public_name vibes-opt)
  (libraries
    findlib.dynload
+   threads
    vibes-log
    vibes-utils
    vibes-patch-info

--- a/vibes-tools/tools/vibes-parse/lib/dune
+++ b/vibes-tools/tools/vibes-parse/lib/dune
@@ -3,6 +3,8 @@
  (public_name vibes-parse)
  (libraries
    bap-core-theory
+   findlib.dynload
+   threads
    vibes-log
    vibes-constants
    vibes-utils

--- a/vibes-tools/tools/vibes-patch-info/lib/dune
+++ b/vibes-tools/tools/vibes-patch-info/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-patch-info)
  (libraries
    findlib.dynload
-   bap
    vibes-log
    vibes-utils
    vibes-higher-vars)

--- a/vibes-tools/tools/vibes-patch/lib/dune
+++ b/vibes-tools/tools/vibes-patch/lib/dune
@@ -4,10 +4,11 @@
  (name vibes_patch)
  (public_name vibes-patch)
  (libraries
-   bap
    bap-elf
    bap-core-theory
+   findlib.dynload
    str
+   threads
    vibes-log
    vibes-constants
    vibes-utils

--- a/vibes-tools/tools/vibes-playground/bin/dune
+++ b/vibes-tools/tools/vibes-playground/bin/dune
@@ -3,7 +3,7 @@
  (public_name vibes-playground)
  (libraries
    findlib.dynload
-   bap
+   bap-main
    bap-core-theory
    cmdliner
    vibes-log

--- a/vibes-tools/tools/vibes-select/lib/dune
+++ b/vibes-tools/tools/vibes-select/lib/dune
@@ -4,7 +4,6 @@
  (name vibes_select)
  (public_name vibes-select)
  (libraries
-   bap
    vibes-ir
    vibes-log
    vibes-linear-ssa

--- a/vibes-tools/tools/vibes-select/lib/dune
+++ b/vibes-tools/tools/vibes-select/lib/dune
@@ -4,6 +4,8 @@
  (name vibes_select)
  (public_name vibes-select)
  (libraries
+   findlib.dynload
+   threads
    vibes-ir
    vibes-log
    vibes-linear-ssa

--- a/vibes-tools/tools/vibes-serializers/lib/dune
+++ b/vibes-tools/tools/vibes-serializers/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-serializers)
  (libraries
    findlib.dynload
-   bap
    vibes-ir
    vibes-constants
    vibes-c-toolkit))

--- a/vibes-tools/tools/vibes-utils/lib/dune
+++ b/vibes-tools/tools/vibes-utils/lib/dune
@@ -3,7 +3,6 @@
  (public_name vibes-utils)
  (libraries
    findlib.dynload
-   bap
    bap-arm
    bap-core-theory
    core


### PR DESCRIPTION
BAP is using dune by default now, so we need to make some slight changes to our build process.