### PR TITLE
Fix generating OGRE segments + fix deleting manual spaces in plugin

### DIFF
--- a/vibes-tools/resources/binja/db.py
+++ b/vibes-tools/resources/binja/db.py
@@ -26,13 +26,17 @@ def get_patches(bv):
   return patches
 
 def save_patch(bv, p):
+  global patches
   ps = bv.query_metadata("vibes.patch-infos")
   ps[p.name] = p.serialize(bv)
+  patches[p.name] = p
   bv.store_metadata("vibes.patch-infos", ps)
 
 def delete_patch(bv, name):
+  global patches
   ps = bv.query_metadata("vibes.patch-infos")
   del ps[name]
+  del patches[name]
   bv.store_metadata("vibes.patch-infos", ps)
   try:
     ps = bv.query_metadata("vibes.patch-codes")
@@ -54,17 +58,21 @@ def get_spaces(bv):
   return spaces
 
 def save_space(bv, space):
+  global spaces
   ss = bv.query_metadata("vibes.patch-spaces")
   ss.append((space.start, space.end))
+  spaces.append(space)
   bv.store_metadata("vibes.patch-spaces", ss)
 
 def delete_space(bv, space):
-  ss = bv.query_metadata("vibes.patch-spaces")
   try:
-    ss.remove(space)
-    bv.store_metadata("vibes.patch-spaces", ss)
+    global spaces
+    spaces.remove(space)
   except ValueError:
     pass
+  ss = filter(lambda s: s[0] != space.start or s[1] != space.end,
+              bv.query_metadata("vibes.patch-spaces"))
+  bv.store_metadata("vibes.patch-spaces", list(ss))
 
 def get_patch_code(bv, name):
   try:

--- a/vibes-tools/resources/binja/ogre.py
+++ b/vibes-tools/resources/binja/ogre.py
@@ -117,8 +117,9 @@ class OGREFunction:
 
 
 class OGREData(OGREAddrSizeOff):
-  def __init__(self, addr, size, off, writable):
+  def __init__(self, addr, size, off, writable, name):
     super(OGREData, self).__init__("", addr, size, off)
+    self.name = name
     self.writable = writable
     self.refs = 1
 
@@ -126,7 +127,8 @@ class OGREData(OGREAddrSizeOff):
     mapped = OGREMapped(self.addr, self.size, self.off)
     segment = OGRESegment(self.addr, self.size,
                           r=True, w=self.writable, x=False)
-    return "\n".join([str(mapped), str(segment)])
+    region = OGRENamedRegion(self.addr, self.size, self.name)
+    return "\n".join([str(mapped), str(segment), str(region)])
 
 
 class OGRE:
@@ -155,7 +157,8 @@ class OGRE:
       if r in self.rodata:
         self.rodata[r].refs += 1
       else:
-        self.rodata[r] = OGREData(r, d[0], d[1], writable=False)
+        self.rodata[r] = \
+          OGREData(addr=r, size=d[0], off=d[1], writable=False, name=d[2])
     return True
 
   def delete_function(self, f):

--- a/vibes-tools/resources/binja/utils.py
+++ b/vibes-tools/resources/binja/utils.py
@@ -67,5 +67,9 @@ def rodata_of_func(bv, f):
       if size <= 0:
         continue
       off = addr_to_off_seg(seg, r)
-      result[r] = (size, off)
+      if d.name is None:
+        name = "data_%x" % r
+      else:
+        name = d.name
+      result[r] = (size, off, name)
   return result

--- a/vibes-tools/tools/vibes-patch/lib/patcher.ml
+++ b/vibes-tools/tools/vibes-patch/lib/patcher.ml
@@ -550,9 +550,11 @@ module Extend_ogre = struct
       let module S = Image.Scheme in
       let addr = patch.addr + len.code in
       let loc = patch.loc + len.code in
+      let name = Format.sprintf "data_%Lx" addr in
       Ogre.sequence [
         Ogre.provide S.mapped addr len.data loc;
         Ogre.provide S.segment addr len.data true false false;
+        Ogre.provide S.named_region addr len.data name;
       ]
     else Ogre.return ()
 


### PR DESCRIPTION
The bookkeeping for the current set of patches and user-specified spaces was broken.

Also, when we provide a `segment` attribute in OGRE, we need to also provide a `named-region` for it to make BAP's image loader happy.