### PR TITLE
Restore most of the unit tests for vibes-tools

### DIFF
--- a/vibes-tools/Makefile
+++ b/vibes-tools/Makefile
@@ -210,3 +210,11 @@ init.install:
 .PHONY:
 init.uninstall:
 	$(MAKE) -C $(TOOLS_SRC) init.uninstall
+
+###################################
+# TEST
+###################################
+
+.PHONY: test
+test:
+	$(MAKE) -C $(TOOLS_SRC) test

--- a/vibes-tools/tools/Makefile
+++ b/vibes-tools/tools/Makefile
@@ -142,3 +142,11 @@ init.install: init.build
 .PHONY: init.uninstall
 init.uninstall:
 	dune uninstall vibes-init
+
+###################################
+# TEST
+###################################
+
+.PHONY: test
+test:
+	dune test

--- a/vibes-tools/tools/vibes-as/test/dune
+++ b/vibes-tools/tools/vibes-as/test/dune
@@ -1,0 +1,8 @@
+(tests
+ (names test_arm)
+ (libraries
+   bap_wp
+   vibes-as
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-as/test/test_arm.ml
+++ b/vibes-tools/tools/vibes-as/test/test_arm.ml
@@ -1,0 +1,496 @@
+open Core
+open Bap.Std
+open Bap_core_theory
+open OUnit2
+
+open KB.Syntax
+
+module Ir = Vibes_ir.Types
+module Asm = Vibes_as.Types.Assembly
+module Selector = Vibes_select.Arm_selector
+
+let dummy_reg_alloc (t : Ir.t) : Ir.t = Ir.map_opvars t ~f:(fun v ->
+    match v.preassign with
+    | Some _ -> v
+    | None ->
+      let var = List.hd_exn v.temps in
+      {v with preassign = Some (Var.create "R0" (Var.typ var))})
+
+let compare_result
+    (expected : string list option)
+    (input : string list option) : bool =
+  let rexpected = Option.map expected ~f:(List.map ~f:Str.regexp) in
+  match input, rexpected with
+  | Some input, Some expected ->
+    begin match List.zip expected input with
+      | Unequal_lengths -> false
+      | Ok pairs ->
+        List.map pairs ~f:(fun (pat, str) ->
+            Str.string_match pat str 0) |>
+        List.for_all ~f:Fn.id
+    end
+  | _ -> false
+
+let print_opt_str_list : string list option -> string = function
+  | Some l -> List.to_string l ~f:Fn.id
+  | None -> "None"
+
+let test_ir
+    (_ : test_ctxt)
+    (sub : unit -> sub term)
+    (expected : string list) : unit =
+  let info = Vibes_patch_info.Types.{
+      patch_point = Word.of_string "0x1234:32";
+      patch_size = 0L;
+      sp_align = 0;
+      patch_vars = [];
+    } in
+  let state = Toplevel.current () in
+  Toplevel.reset ();
+  let result = Toplevel.var "select-arm" in
+  let sub = sub () in
+  Toplevel.put result begin
+    let target = Theory.Target.of_string "bap:armv7+le" in
+    let language = Theory.Language.of_string "bap:llvm-armv7" in
+    let+ ir = Selector.select sub ~is_thumb:false in
+    let ir = dummy_reg_alloc ir in
+    let printer = match Vibes_as.Utils.asm_printer target language with
+      | Ok p -> p
+      | Error e ->
+        failwith @@
+        Format.asprintf "Failed to get ASM printer: %a" KB.Conflict.pp e in
+    printer ir info |> Result.ok |> Option.map ~f:(fun asm ->
+        Asm.blocks asm |> List.concat_map ~f:(fun blk ->
+            (Asm.label blk ^ ":") :: Asm.insns blk))
+  end;
+  let result = Toplevel.get result in
+  Toplevel.set state;
+  assert_equal (Some expected) result
+    ~cmp:compare_result
+    ~printer:print_opt_str_list
+
+
+let v1 : var = Var.create "v1" (Imm 32)
+let v2 : var = Var.create "v2" (Imm 32)
+let v3 : var = Var.create "v3" (Imm 32)
+let v : var = Var.create "v" (Imm 1)
+let func () : tid = Tid.for_name "some_function"
+let mem : var = Var.create "mem" (Mem (`r32, `r8))
+let (!!) (i : int) : exp = Bil.int (Word.of_int ~width:32 i)
+
+let add_goto (sub : sub term) (tgt : tid) : sub term =
+  Term.map blk_t sub ~f:(fun blk ->
+      let blk = Blk.Builder.init blk in
+      Blk.Builder.add_jmp blk @@ Jmp.create @@ Goto (Label.direct tgt);
+      Blk.Builder.result blk)
+
+let add_call (sub : sub term) (tgt : tid) : sub term =
+  Term.map blk_t sub ~f:(fun blk ->
+      let return_blk = Blk.Builder.create () |> Blk.Builder.result in
+      let blk = Blk.Builder.init blk in
+      let call = Call.create ()
+          ~return:(Label.direct @@ Term.tid return_blk)
+          ~target:(Label.direct tgt) in
+      Blk.Builder.add_jmp blk @@ Jmp.create @@ Call call;
+      Blk.Builder.result blk)
+
+module Prog1 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 + var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog2 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 + (var v3 + var v1)] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog3 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 lsl var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog4 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 lsr var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog5 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 land var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog6 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 lor var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog9 = struct
+
+  let prog () : sub term =
+    let tgt = Bap.Std.Tid.for_name "tgt" in
+    let bil = [] in
+    let prog = Bap_wp.Bil_to_bir.bil_to_sub bil in
+    add_goto prog tgt
+
+end
+
+module Prog10 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[mem := store ~mem:(var mem) ~addr:(var v1) (var v2) BigEndian `r32] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog11 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v2 := load ~mem:(var mem) ~addr:(var v1) BigEndian `r32] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog12 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[if_ (var v) [v1 := !!3] [v1 := !!4]] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog13 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v2 := load ~mem:(var mem) ~addr:(var v1) BigEndian `r16] in
+    let res = Bap_wp.Bil_to_bir.bil_to_sub bil in
+    res
+
+end
+
+module Prog14 = struct
+
+  let prog () =
+    let bil = [] in
+    let prog = Bap_wp.Bil_to_bir.bil_to_sub bil in
+    add_call prog @@ func ()
+
+end
+
+module Prog15 = struct
+
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 + !!42] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog16 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog17 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := !!5000] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog18 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[if_ (var v <> !!0) [v1 := !!3] [v1 := !!4]] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog19 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[mem := store ~mem:(var mem) ~addr:(var v1 + !!8) (var v2) BigEndian `r32] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog20 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 * !!5] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog21 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := var v2 * !!8] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog22 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := !!0x1FFFF] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog23 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := lnot @@ var v2; v2 := unop neg @@ var v3] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog24 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[
+        v1 := !!1 lsl !!3;
+        v2 := !!1 lsl var v1;
+        v3 := var v2 lor !!6;
+      ] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog25 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[if_ (var v1 > !!42) [v1 := !!3] [v1 := !!4]] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+module Prog26 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[if_ (lnot (var v)) [v1 := !!3] [v1 := !!4]] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
+let blk_pat : string = "blk\\([0-9]\\|[a-f]\\)*"
+
+let test_ir1 (ctxt : test_ctxt) : unit = test_ir ctxt Prog1.prog [
+    blk_pat ^ ":";
+    "add R0, R0, R0";
+  ]
+
+let test_ir2 (ctxt : test_ctxt) : unit = test_ir ctxt Prog2.prog [
+    blk_pat ^ ":";
+    "add R0, R0, R0";
+    "add R0, R0, R0";
+  ]
+
+let test_ir3 (ctxt : test_ctxt) : unit = test_ir ctxt Prog3.prog [
+    blk_pat ^ ":";
+    "lsl R0, R0, R0";
+  ]
+
+let test_ir4 (ctxt : test_ctxt) : unit = test_ir ctxt Prog4.prog [
+    blk_pat ^ ":";
+    "lsr R0, R0, R0";
+  ]
+
+let test_ir5 (ctxt : test_ctxt) : unit = test_ir ctxt Prog5.prog [
+    blk_pat ^ ":";
+    "and R0, R0, R0";
+  ]
+
+let test_ir6 (ctxt : test_ctxt) : unit = test_ir ctxt Prog6.prog [
+    blk_pat ^ ":";
+    "orr R0, R0, R0";
+  ]
+
+let test_ir9 (ctxt : test_ctxt) : unit = test_ir ctxt Prog9.prog [
+    blk_pat ^ ":";
+    "b tgt";
+  ]
+
+let test_ir10 (ctxt : test_ctxt) : unit = test_ir ctxt Prog10.prog [
+    blk_pat ^ ":";
+    "str R0, \\[R0\\]"
+  ]
+
+let test_ir11 (ctxt : test_ctxt) : unit = test_ir ctxt Prog11.prog [
+    blk_pat ^ ":";
+    "ldr R0, \\[R0\\]";
+  ]
+
+let test_ir12 (ctxt : test_ctxt) : unit = test_ir ctxt Prog12.prog [
+    blk_pat ^ ":";
+    "cmp R0, #0";
+    "bne " ^ blk_pat;
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #4";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #3";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+  ]
+
+let test_ir13 (ctxt : test_ctxt) : unit = test_ir ctxt Prog13.prog [
+    blk_pat ^ ":";
+    "ldrh R0, \\[R0\\]";
+  ]
+
+let test_ir14 (ctxt : test_ctxt) : unit = test_ir ctxt Prog14.prog [
+    blk_pat ^ ":";
+    "bl some_function";
+    "b " ^ blk_pat;
+  ]
+
+let test_ir15 (ctxt : test_ctxt) : unit = test_ir ctxt Prog15.prog [
+    blk_pat ^ ":";
+    "add R0, R0, #42";
+  ]
+
+let test_ir16 (ctxt : test_ctxt) : unit = test_ir ctxt Prog16.prog
+    [blk_pat ^ ":";
+     "mov R0, R0";
+    ]
+
+let test_ir17 (ctxt : test_ctxt) : unit = test_ir ctxt Prog17.prog [
+    blk_pat ^ ":";
+    "movw R0, #5000";
+  ]
+
+let test_ir18 (ctxt : test_ctxt) : unit = test_ir ctxt Prog18.prog [
+    blk_pat ^ ":";
+    "cmp R0, #0";
+    "bne " ^ blk_pat;
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #4";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #3";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+  ]
+
+let test_ir19 (ctxt : test_ctxt) : unit = test_ir ctxt Prog19.prog [
+    blk_pat ^ ":";
+    "str R0, \\[R0, #8\\]";
+  ]
+
+let test_ir20 (ctxt : test_ctxt) : unit = test_ir ctxt Prog20.prog [
+    blk_pat ^ ":";
+    "mov R0, #5";
+    "mul R0, R0, R0";
+  ]
+
+let test_ir21 (ctxt : test_ctxt) : unit = test_ir ctxt Prog21.prog [
+    blk_pat ^ ":";
+    "lsl R0, R0, #3";
+  ]
+
+let test_ir22 (ctxt : test_ctxt) : unit = test_ir ctxt Prog22.prog [
+    blk_pat ^ ":";
+    "ldr R0, =131071";
+  ]
+
+let test_ir23 (ctxt : test_ctxt) : unit = test_ir ctxt Prog23.prog [
+    blk_pat ^ ":";
+    "mvn R0, R0";
+    "neg R0, R0"
+  ]
+
+let test_ir24 (ctxt : test_ctxt) : unit = test_ir ctxt Prog24.prog [
+    blk_pat ^ ":";
+    "mov R0, #8";
+    "mov R0, #1";
+    "lsl R0, R0, R0";
+    "mov R0, #6";
+    "orr R0, R0, R0";
+  ]
+
+let test_ir25 (ctxt : test_ctxt) : unit = test_ir ctxt Prog25.prog [
+    blk_pat ^ ":";
+    "cmp R0, #42";
+    "bhi " ^ blk_pat;
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #4";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #3";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+  ]
+
+let test_ir26 (ctxt : test_ctxt) : unit = test_ir ctxt Prog26.prog [
+    blk_pat ^ ":";
+    "cmp R0, #0";
+    "beq " ^ blk_pat;
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #4";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+    "mov R0, #3";
+    "b " ^ blk_pat;
+    blk_pat ^ ":";
+  ]
+
+let suite : test = "Test ARM selector" >::: [
+    "Test Arm.ir 1" >:: test_ir1;
+    "Test Arm.ir 2" >:: test_ir2;
+    "Test Arm.ir 3" >:: test_ir3;
+    "Test Arm.ir 4" >:: test_ir4;
+    "Test Arm.ir 5" >:: test_ir5;
+    "Test Arm.ir 6" >:: test_ir6;
+    "Test Arm.ir 9" >:: test_ir9;
+    "Test Arm.ir 10" >:: test_ir10;
+    "Test Arm.ir 11" >:: test_ir11;
+    "Test Arm.ir 12" >:: test_ir12;
+    "Test Arm.ir 13" >:: test_ir13;
+    "Test Arm.ir 14" >:: test_ir14;
+    "Test Arm.ir 15" >:: test_ir15;
+    "Test Arm.ir 16" >:: test_ir16;
+    "Test Arm.ir 17" >:: test_ir17;
+    "Test Arm.ir 18" >:: test_ir18;
+    "Test Arm.ir 19" >:: test_ir19;
+    "Test Arm.ir 20" >:: test_ir20;
+    "Test Arm.ir 21" >:: test_ir21;
+    "Test Arm.ir 22" >:: test_ir22;
+    "Test Arm.ir 23" >:: test_ir23;
+    "Test Arm.ir 24" >:: test_ir24;
+    "Test Arm.ir 25" >:: test_ir25;
+    "Test Arm.ir 26" >:: test_ir26;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-as/test/test_arm.ml
+++ b/vibes-tools/tools/vibes-as/test/test_arm.ml
@@ -70,7 +70,6 @@ let test_ir
     ~cmp:compare_result
     ~printer:print_opt_str_list
 
-
 let v1 : var = Var.create "v1" (Imm 32)
 let v2 : var = Var.create "v2" (Imm 32)
 let v3 : var = Var.create "v3" (Imm 32)
@@ -296,6 +295,14 @@ module Prog26 = struct
 
 end
 
+module Prog27 = struct
+
+  let prog () : sub term =
+    let bil = Bil.[v1 := !!(-1)] in
+    Bap_wp.Bil_to_bir.bil_to_sub bil
+
+end
+
 let blk_pat : string = "blk\\([0-9]\\|[a-f]\\)*"
 
 let test_ir1 (ctxt : test_ctxt) : unit = test_ir ctxt Prog1.prog [
@@ -462,31 +469,37 @@ let test_ir26 (ctxt : test_ctxt) : unit = test_ir ctxt Prog26.prog [
     blk_pat ^ ":";
   ]
 
+let test_ir27 (ctxt : test_ctxt) : unit = test_ir ctxt Prog27.prog [
+    blk_pat ^ ":";
+    "mvn R0, #0";
+  ]
+
 let suite : test = "Test ARM selector" >::: [
-    "Test Arm.ir 1" >:: test_ir1;
-    "Test Arm.ir 2" >:: test_ir2;
-    "Test Arm.ir 3" >:: test_ir3;
-    "Test Arm.ir 4" >:: test_ir4;
-    "Test Arm.ir 5" >:: test_ir5;
-    "Test Arm.ir 6" >:: test_ir6;
-    "Test Arm.ir 9" >:: test_ir9;
-    "Test Arm.ir 10" >:: test_ir10;
-    "Test Arm.ir 11" >:: test_ir11;
-    "Test Arm.ir 12" >:: test_ir12;
-    "Test Arm.ir 13" >:: test_ir13;
-    "Test Arm.ir 14" >:: test_ir14;
-    "Test Arm.ir 15" >:: test_ir15;
-    "Test Arm.ir 16" >:: test_ir16;
-    "Test Arm.ir 17" >:: test_ir17;
-    "Test Arm.ir 18" >:: test_ir18;
-    "Test Arm.ir 19" >:: test_ir19;
-    "Test Arm.ir 20" >:: test_ir20;
-    "Test Arm.ir 21" >:: test_ir21;
-    "Test Arm.ir 22" >:: test_ir22;
-    "Test Arm.ir 23" >:: test_ir23;
-    "Test Arm.ir 24" >:: test_ir24;
-    "Test Arm.ir 25" >:: test_ir25;
-    "Test Arm.ir 26" >:: test_ir26;
+    "Test ARM 1" >:: test_ir1;
+    "Test ARM 2" >:: test_ir2;
+    "Test ARM 3" >:: test_ir3;
+    "Test ARM 4" >:: test_ir4;
+    "Test ARM 5" >:: test_ir5;
+    "Test ARM 6" >:: test_ir6;
+    "Test ARM 9" >:: test_ir9;
+    "Test ARM 10" >:: test_ir10;
+    "Test ARM 11" >:: test_ir11;
+    "Test ARM 12" >:: test_ir12;
+    "Test ARM 13" >:: test_ir13;
+    "Test ARM 14" >:: test_ir14;
+    "Test ARM 15" >:: test_ir15;
+    "Test ARM 16" >:: test_ir16;
+    "Test ARM 17" >:: test_ir17;
+    "Test ARM 18" >:: test_ir18;
+    "Test ARM 19" >:: test_ir19;
+    "Test ARM 20" >:: test_ir20;
+    "Test ARM 21" >:: test_ir21;
+    "Test ARM 22" >:: test_ir22;
+    "Test ARM 23" >:: test_ir23;
+    "Test ARM 24" >:: test_ir24;
+    "Test ARM 25" >:: test_ir25;
+    "Test ARM 26" >:: test_ir26;
+    "Test ARM 27" >:: test_ir27;
   ]
 
 let () = match Bap_main.init () with

--- a/vibes-tools/tools/vibes-c-toolkit/test/dune
+++ b/vibes-tools/tools/vibes-c-toolkit/test/dune
@@ -1,5 +1,7 @@
 (tests
- (names test_core)
+ (names
+   test_core
+   test_parse)
  (libraries
    vibes-c-toolkit
    findlib.dynload

--- a/vibes-tools/tools/vibes-c-toolkit/test/dune
+++ b/vibes-tools/tools/vibes-c-toolkit/test/dune
@@ -1,0 +1,7 @@
+(tests
+ (names test_core)
+ (libraries
+   vibes-c-toolkit
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-c-toolkit/test/test_core.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/test/test_core.ml
@@ -26,8 +26,8 @@ let assert_parse_eq ?(hvars = []) c bil =
       c KB.Conflict.pp e
   | Ok ast ->
     let state = Toplevel.current () in
-    let result = Toplevel.var "core-c" in
     Toplevel.reset ();
+    let result = Toplevel.var "core-c" in
     Toplevel.put result begin
       let* theory = Theory.instance () in
       let* (module Core) = Theory.require theory in

--- a/vibes-tools/tools/vibes-c-toolkit/test/test_core.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/test/test_core.ml
@@ -1,0 +1,492 @@
+open Core
+open Bap.Std
+open Bap_core_theory
+open Vibes_c_toolkit
+open OUnit2
+
+open KB.Syntax
+
+module Higher_var = Vibes_higher_vars.Higher_var
+
+let eff_to_str (bil : bil) : string =
+  Format.asprintf "%a" Bil.pp bil |>  
+  String.filter ~f:(fun c -> not Char.(c = '\"'))
+
+let strip : string -> string =
+  String.filter ~f:(Fn.non Char.is_whitespace)
+
+let compare_sem (sem : string) (str : string) : bool =
+  String.equal (strip sem) (strip str)
+
+let assert_parse_eq ?(hvars = []) c bil =
+  match Parse_c.parse c with
+  | Error e ->
+    assert_failure @@
+    Format.asprintf "FrontC failed to parse:\n\n%s\n\nwith error %a"
+      c KB.Conflict.pp e
+  | Ok ast ->
+    let state = Toplevel.current () in
+    let result = Toplevel.var "core-c" in
+    Toplevel.reset ();
+    Toplevel.put result begin
+      let* theory = Theory.instance () in
+      let* (module Core) = Theory.require theory in
+      let module C_compiler = Core_c.Make(Core) in
+      let target = Theory.Target.of_string "bap:armv7+le" in
+      C_compiler.compile hvars target ast
+    end;
+    let sem = Toplevel.get result in
+    let s = eff_to_str @@ Insn.bil sem in
+    Toplevel.set state;
+    assert_equal bil s ~cmp:compare_sem ~printer:Fn.id
+
+let test_var_decl _ =
+  assert_parse_eq
+    "int x, y, z;"
+    "{ }"
+
+let test_assign _ =
+  assert_parse_eq
+    "int x, y; x = y;"
+    "{ x := y }"
+
+let test_seq _ =
+  assert_parse_eq
+    "int x, y, z; x = y; y = z;"
+    "{ x := y y := z }"
+
+let test_ite _ =
+  assert_parse_eq
+    "int cond_expr;
+     if(cond_expr) {
+     l2:
+       goto l1;
+     } else {
+     l1:
+       goto l2;
+     }"
+    "{
+       if (cond_expr <> 0) {
+         label(%00000003)
+         call(l1)
+       } else {
+         label(%00000004)
+         call(l2)
+       }
+     }"
+
+let test_fallthrough _ =
+  assert_parse_eq
+    "int x, y, z; if (x) { goto l; } x = z; l: (void)x; "
+    "{
+       if (x <> 0) {
+         call(l)
+       }
+       x := z
+       label(%00000003)
+     }"
+
+let test_array _ =
+  assert_parse_eq
+    "int* a, y; y = a[7];"
+    "{ y := mem[a + 0x1C, el]:u32 }"
+
+let test_array_multi_ptr _ =
+  assert_parse_eq
+    "int** a, y; y = a[1][2];"
+    "{ y := mem[mem[a + 4, el]:u32 + 8, el]:u32 }"
+
+let test_compound _ =
+  assert_parse_eq
+    "int x, *y, z;
+     char q;
+     larry:
+     x = 0x7;
+     fred:
+     x = *y;
+     if(x > 0){
+       goto fred;
+     } else {
+       goto larry;
+     }"
+    "{
+       label(%00000002)
+       x := 7
+       label(%00000003)
+       x := mem[y, el]:u32
+       if (0 <$ x) {
+         call(fred)
+       } else {
+         call(larry)
+       }
+     }"
+
+let test_call_hex _ =
+  assert_parse_eq
+    "int temp;
+     if (temp == 0) { ((void (*)())0x3ec)(); }"
+    "{
+       if (temp = 0) {
+         jmp 0x3EC
+       }
+     }"
+
+let test_call_args_1 _ =
+  assert_parse_eq
+    "int a, b, c;
+     void (*f)(int, int, int);
+     f(a, b, c);"
+    "{
+       goto(%00000006)
+       label(%00000006)
+       reg:R0 := a
+       reg:R1 := b
+       reg:R2 := c
+       call(f)
+     }"
+
+let test_call_args_2 _ =
+  assert_parse_eq
+    "int a, c;
+     void (*f)(int, int, int);
+     f(a, 0x1234, c);"
+    "{
+       goto(%00000005)
+       label(%00000005)
+       reg:R0 := a
+       reg:R1 := 0x1234
+       reg:R2 := c
+       call(f)
+     }"
+
+let test_call_args_eff _ =
+  assert_parse_eq
+    "int a, b, c;
+     void (*f)(int, int, int);
+     f(a, b++, ++c);"
+    "{
+       #0 := b
+       b := b + 1
+       c := c + 1
+       goto(%00000009)
+       label(%00000009)
+       reg:R0 := a
+       reg:R1 := #0
+       reg:R2 := c
+       call(f)
+     }"
+
+let test_call_args_ret _ =
+  assert_parse_eq
+    "int a, b, c, d;
+     int (*f)(int, int, int);
+     d = f(a, b, c);"
+    "{
+       goto(%00000006)
+       label(%00000006)
+       reg:R0 := a
+       reg:R1 := b
+       reg:R2 := c
+       call(f)
+       d := reg:R0
+     }"
+
+let test_call_args_ret_store _ =
+  assert_parse_eq
+    "int a, b, c;
+     int *d;
+     int (*f)(int, int, int);
+     d = (int*)(a + 0x1337);
+     *d = f(a, b, c);"
+    "{
+       d := a + 0x1337
+       goto(%00000007)
+       label(%00000007)
+       reg:R0 := a
+       reg:R1 := b
+       reg:R2 := c
+       call(f)
+       #0 := reg:R0
+       mem := mem with [d, el]:u32 <- #0
+     }"
+
+let test_call_args_addrof _ =
+  let hvars = Higher_var.[
+      {
+        name = "c";
+        value = Memory (Frame ("SP", Word.of_int ~width:32 8));
+      };
+    ] in
+  assert_parse_eq ~hvars
+    "int a, b, *c, d;
+     void (*f)(int, int, int**);
+     f(a, b, &c);
+     d = *c;"
+    "{
+       goto(%00000006)
+       label(%00000006)
+       reg:R0 := a
+       reg:R1 := b
+       reg:R2 := reg:SP + 8
+       call(f)
+       d := mem[c, el]:u32
+     }"
+
+let test_load_short _ =
+  assert_parse_eq
+    "int x, y;
+     x = * (short *) y;"
+    "{ x := extend:32[mem[y, el]:u16] }"
+
+let test_load_ushort _ =
+  assert_parse_eq
+    "int x, y;
+     x = * (unsigned short *) y;"
+    "{ x := pad:32[mem[y, el]:u16] }"
+
+let test_ternary_assign _ =
+  assert_parse_eq
+    "int (*f)();
+     int x, c;
+     x = c ? f() : 5;"
+    "{
+      if (c <> 0) {
+        call(f)
+        x := reg:R0
+      }
+      else {
+        x := 5
+      }
+     }"
+
+let test_ternary_posincr _ =
+  assert_parse_eq
+    "int x, y, z, c;
+     z = (c ? x : y)++;"
+    "{
+      if (c <> 0) {
+        #0 := x
+        x := x + 1
+      }
+      else {
+        #0 := y
+        y := y + 1
+      }
+      z := #0
+     }"
+
+let test_ternary_eff _ =
+  assert_parse_eq
+    "void (*f)();
+     int c, x, y;
+     (c ? f() : (void)(x = 5));
+     y = x;"
+    "{
+       if (c <> 0) {
+         call(f)
+       }
+       else {
+         x := 5
+       }
+       y := x
+     }"
+
+let test_posincr _ =
+  assert_parse_eq
+    "int x; x++;"
+    "{ x := x + 1 }"
+
+let test_posincr_assign _ =
+  assert_parse_eq
+    "int x, y; y = x++;"
+    "{
+       #0 := x
+       x := x + 1
+       y := #0
+     }"
+
+let test_preincr _ =
+  assert_parse_eq
+    "int x; ++x;"
+    "{ x := x + 1 }"
+
+let test_preincr_assign _ =
+  assert_parse_eq
+    "int x, y; y = ++x;"
+    "{
+       x := x + 1
+       y := x
+     }"
+
+let test_and_short_circ _ =
+  assert_parse_eq
+    "int x, y;
+     int (*f)();
+     if (x && f()) {
+       y = 5;
+     }"
+    "{
+       #1 := x
+       if (#1 <> 0) {
+         call(f)
+         #0 := reg:R0
+         #1 := #0
+       }
+       if (#1 <> 0) {
+         y := 5
+       }
+     }"
+
+let test_or_short_circ _ =
+  assert_parse_eq
+    "int x, y;
+     int (*f)();
+     if (x || f()) {
+       y = 5;
+     }"
+    "{
+       #1 := x
+       if (#1 <> 0) {
+       }
+       else {
+         call(f)
+         #0 := reg:R0
+         #1 := #0
+       }
+       if (#1 <> 0) {
+         y := 5
+       }
+     }"
+
+let test_add_assign _ =
+  assert_parse_eq
+    "int x, y;
+     (x += y) += (y += x);"
+    "{
+       y := y + x
+       x := x + y
+       x := x + y
+     }"
+
+let test_ternary_compound _ =
+  assert_parse_eq
+    "int c, x, y, z;
+     z = (c ? x : y) += 5;"
+    "{
+       if (c <> 0) {
+         x := x + 5
+         #0 := x
+       }
+       else {
+         y := y + 5
+         #0 := y
+       }
+       z := #0
+     }"
+
+let test_comma _ =
+  assert_parse_eq
+    "int x, y, z;
+     z = (x = 5, y * x);"
+    "{
+       x := 5
+       z := y * x
+     }"
+
+let test_comma_ambig _ =
+  assert_parse_eq
+    "int x, y, z;
+     z = x = 5, y * x;"
+    "{
+       x := 5
+       z := x
+     }"
+
+let test_ternary_deref _ =
+  assert_parse_eq
+    "int c, *x, *y;
+     *(c ? x : y) = 5;"
+    "{
+       if (c <> 0) {
+         #0 := x
+       }
+       else {
+         #0 := y
+       }
+       mem := mem with [#0, el]:u32 <- 5
+     }"
+
+let test_char_deref_posincr _ =
+  assert_parse_eq
+    "char *a, *b;
+     *a++ = *b++;"
+    "{
+       #0 := mem[b]
+       b := b + 1
+       mem := mem with [a] <- #0
+       a := a + 1
+     }"
+
+let test_bool_not _ =
+  assert_parse_eq
+    "int x, y;
+     if (!x) {
+       x = y;
+     }"
+    "{
+       if (x = 0) {
+         x := y
+       }
+     }"
+
+let test_mixed_sorts _ =
+  assert_parse_eq
+    "int x, y;
+     x += (y == 0);"
+    "{
+       x := x + pad:32[y = 0]
+     }"
+
+let suite : test = "Test Core C" >::: [
+  "Test vardecls" >:: test_var_decl;
+  "Test assignment" >:: test_assign;
+  "Test seq" >:: test_seq;
+  "Test ite" >:: test_ite;
+  "Test array" >:: test_array;
+  "Test array multi ptr" >:: test_array_multi_ptr;
+  "Test fallthrough" >:: test_fallthrough;
+  "Test compound" >:: test_compound;
+  "Test call hex" >:: test_call_hex;
+  "Test call args 1" >:: test_call_args_1;
+  "Test call args 2" >:: test_call_args_2;
+  "Test call args eff" >:: test_call_args_eff;
+  "Test call args ret" >:: test_call_args_ret;
+  "Test call args ret store" >:: test_call_args_ret_store;
+  "Test call args addrof" >:: test_call_args_addrof;
+  "Test load short" >:: test_load_short;
+  "Test load unsigned short" >:: test_load_ushort;
+  "Test ternary assign" >:: test_ternary_assign;
+  "Test ternary post increment" >:: test_ternary_posincr;
+  "Test ternary effect" >:: test_ternary_eff;
+  "Test post increment" >:: test_posincr;
+  "Test post increment assign" >:: test_posincr_assign;
+  "Test pre increment" >:: test_preincr;
+  "Test pre increment assign" >:: test_preincr_assign;
+  "Test AND short-circuit" >:: test_and_short_circ;
+  "Test OR short-circuit" >:: test_or_short_circ;
+  "Test ADD_ASSIGN" >:: test_add_assign;
+  "Test ternary compound" >:: test_ternary_compound;
+  "Test comma" >:: test_comma;
+  "Test comma ambiguous" >:: test_comma_ambig;
+  "Test ternary deref" >:: test_ternary_deref;
+  "Test char deref post increment" >:: test_char_deref_posincr;
+  "Test bool not" >:: test_bool_not;
+  "Test mixed sorts" >:: test_mixed_sorts;
+]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-c-toolkit/test/test_parse.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/test/test_parse.ml
@@ -67,61 +67,60 @@ let assert_eq (s : string) (p : Patch_c.stmt) : unit =
     Toplevel.get result;
     Toplevel.set state
 
-
-let test_void_ptr_implicit_downcast _ =
+let test_void_ptr_implicit_downcast (_ : test_ctxt) =
   assert_ok
     "int *x;
      void* (*malloc)(int);
      x = malloc(42);"
 
-let test_void_ptr_implicit_upcast _ =
+let test_void_ptr_implicit_upcast (_ : test_ctxt) =
   assert_ok
     "void *x;
      int* (*f)(int);
      x = f(5);"
 
-let test_bad_ptr_cast _ =
+let test_bad_ptr_cast (_ : test_ctxt) =
   assert_error
     "int *x;
      char* (*f)();
      x = f();"
 
-let test_bad_arg_arity _ =
+let test_bad_arg_arity (_ : test_ctxt) =
   assert_error
     "void (*f)(int, int);
      f(1, 2, 3);"
 
-let test_bad_arg_types _ =
+let test_bad_arg_types (_ : test_ctxt) =
   assert_error
     "void (*f)(int, int);
      f(1, (int*)2);"
 
-let test_discard _ =
+let test_discard (_ : test_ctxt) =
   assert_ok
     "int (*maybe_effectful)(int);
      (void)maybe_effectful(5);"
 
-let test_bad_discard _ =
+let test_bad_discard (_ : test_ctxt) =
   assert_error
     "int x, y;
      x = (void)(y = 5);"
 
-let test_ptr_arith _ =
+let test_ptr_arith (_ : test_ctxt) =
   assert_ok
     "int x, *y, z;
      z = *(y + x);"
 
-let test_bad_ptr_arith _ =
+let test_bad_ptr_arith (_ : test_ctxt) =
   assert_error
     "int x, *y, z;
      z = *(y / x);"
 
-let test_bad_lvalue_posincr _ =
+let test_bad_lvalue_posincr (_ : test_ctxt) =
   assert_error
     "int x, y;
      x++ = y;"
 
-let test_char_assign _ =
+let test_char_assign (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 8 in
@@ -132,7 +131,7 @@ let test_char_assign _ =
     ASSIGN ((v, t), CONST_INT (c, UNSIGNED)) in
   assert_eq "char x; x = 'a';" p
 
-let test_char_assign_ext _ =
+let test_char_assign_ext (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 32 in
@@ -143,7 +142,7 @@ let test_char_assign_ext _ =
     ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
   assert_eq "int x; x = 'a';" p
 
-let test_int_assign _ =
+let test_int_assign (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 32 in
@@ -154,7 +153,7 @@ let test_int_assign _ =
     ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
   assert_eq "int x; x = 255;" p
 
-let test_char_assign_signed_ext _ =
+let test_char_assign_signed_ext (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 32 in
@@ -165,7 +164,7 @@ let test_char_assign_signed_ext _ =
     ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
   assert_eq "int x; x = (signed char)255;" p
 
-let test_char_assign_unsigned_ext _ =
+let test_char_assign_unsigned_ext (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 32 in
@@ -182,7 +181,7 @@ let test_char_assign_unsigned_ext _ =
    See example 9 in:
    https://people.eecs.berkeley.edu/~necula/cil/cil016.html
 *)
-let test_cast_precedence _ =
+let test_cast_precedence (_ : test_ctxt) =
   let p =
     let open Patch_c in
     let s = Theory.Bitv.define 32 in

--- a/vibes-tools/tools/vibes-c-toolkit/test/test_parse.ml
+++ b/vibes-tools/tools/vibes-c-toolkit/test/test_parse.ml
@@ -1,0 +1,234 @@
+open Core
+open Bap.Std
+open Bap_c.Std
+open Bap_core_theory
+open Vibes_c_toolkit
+open OUnit2
+
+open KB.Syntax
+
+let assert_error (s : string) : unit = match Parse_c.parse s with
+  | Error e ->
+    assert_failure @@
+    Format.asprintf "FrontC failed to parse:\n\n%s\n\nwith error %a"
+      s KB.Conflict.pp e
+  | Ok ast ->
+    let state = Toplevel.current () in
+    Toplevel.reset ();
+    try
+      let result = Toplevel.var "patch-c" in
+      Toplevel.put result begin
+        let target = Theory.Target.of_string "bap:armv7+le" in
+        let+ prog = Patch_c.translate ast ~target in
+        failwithf "Expected error:\n\n%s\n\nis not well-formed"
+          (Patch_c.to_string prog) ()
+      end;
+      Toplevel.get result
+    with
+    | Toplevel.Conflict _ -> Toplevel.set state
+    | exn ->
+      Toplevel.set state;
+      raise exn
+
+let assert_ok (s : string) : unit = match Parse_c.parse s with
+  | Error e ->
+    assert_failure @@
+    Format.asprintf "FrontC failed to parse:\n\n%s\n\nwith error %a"
+      s KB.Conflict.pp e
+  | Ok ast ->
+    let state = Toplevel.current () in
+    Toplevel.reset ();
+    let result = Toplevel.var "patch-c" in
+    Toplevel.put result begin
+      let target = Theory.Target.of_string "bap:armv7+le" in
+      let+ _prog = Patch_c.translate ast ~target in
+      ()
+    end;
+    Toplevel.get result;
+    Toplevel.set state
+
+let assert_eq (s : string) (p : Patch_c.stmt) : unit =
+  match Parse_c.parse s with
+  | Error e ->
+    assert_failure @@
+    Format.asprintf "FrontC failed to parse:\n\n%s\n\nwith error %a"
+      s KB.Conflict.pp e
+  | Ok ast ->
+    let state = Toplevel.current () in
+    Toplevel.reset ();
+    let result = Toplevel.var "patch-c" in
+    Toplevel.put result begin
+      let target = Theory.Target.of_string "bap:armv7+le" in
+      let+ prog = Patch_c.translate ast ~target in
+      assert_equal p prog.body.stmt
+        ~cmp:Patch_c.Stmt.equal
+        ~printer:Patch_c.Stmt.to_string
+    end;
+    Toplevel.get result;
+    Toplevel.set state
+
+
+let test_void_ptr_implicit_downcast _ =
+  assert_ok
+    "int *x;
+     void* (*malloc)(int);
+     x = malloc(42);"
+
+let test_void_ptr_implicit_upcast _ =
+  assert_ok
+    "void *x;
+     int* (*f)(int);
+     x = f(5);"
+
+let test_bad_ptr_cast _ =
+  assert_error
+    "int *x;
+     char* (*f)();
+     x = f();"
+
+let test_bad_arg_arity _ =
+  assert_error
+    "void (*f)(int, int);
+     f(1, 2, 3);"
+
+let test_bad_arg_types _ =
+  assert_error
+    "void (*f)(int, int);
+     f(1, (int*)2);"
+
+let test_discard _ =
+  assert_ok
+    "int (*maybe_effectful)(int);
+     (void)maybe_effectful(5);"
+
+let test_bad_discard _ =
+  assert_error
+    "int x, y;
+     x = (void)(y = 5);"
+
+let test_ptr_arith _ =
+  assert_ok
+    "int x, *y, z;
+     z = *(y + x);"
+
+let test_bad_ptr_arith _ =
+  assert_error
+    "int x, *y, z;
+     z = *(y / x);"
+
+let test_bad_lvalue_posincr _ =
+  assert_error
+    "int x, y;
+     x++ = y;"
+
+let test_char_assign _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 8 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `char in
+    let c = Word.of_int ~width:8 @@ Char.to_int 'a' in
+    let c = Word.signed c in
+    ASSIGN ((v, t), CONST_INT (c, UNSIGNED)) in
+  assert_eq "char x; x = 'a';" p
+
+let test_char_assign_ext _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 32 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `sint in
+    let c = Word.of_int ~width:32 @@ Char.to_int 'a' in
+    let c = Word.signed c in
+    ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
+  assert_eq "int x; x = 'a';" p
+
+let test_int_assign _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 32 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `sint in
+    let c = Word.of_int ~width:32 255 in
+    let c = Word.signed c in
+    ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
+  assert_eq "int x; x = 255;" p
+
+let test_char_assign_signed_ext _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 32 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `sint in
+    let c = Word.of_int ~width:32 (-1) in
+    let c = Word.signed c in
+    ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
+  assert_eq "int x; x = (signed char)255;" p
+
+let test_char_assign_unsigned_ext _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 32 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `sint in
+    let c = Word.of_int ~width:32 255 in
+    let c = Word.signed c in
+    ASSIGN ((v, t), CONST_INT (c, SIGNED)) in
+  assert_eq "int x; x = (char)255;" p
+
+(* NOTE: this is actually a bug with FrontC. The precedence of
+   the cast versus the unary minus operator is not correct.
+
+   See example 9 in:
+   https://people.eecs.berkeley.edu/~necula/cil/cil016.html
+*)
+let test_cast_precedence _ =
+  let p =
+    let open Patch_c in
+    let s = Theory.Bitv.define 32 in
+    let v = Theory.Var.(forget @@ define s "x") in
+    let t = C.Type.basic `ulong in
+    let t' = C.Type.basic `sint in
+    let cl = Word.of_int ~width:32 1 in
+    let cr = Word.of_int ~width:32 8 in
+    ASSIGN (
+      (v, t),
+      CAST (
+        t,
+        UNARY (
+          MINUS,
+          BINARY (
+            DIV,
+            CONST_INT (cl, SIGNED),
+            CONST_INT (cr, SIGNED),
+            t'),
+          t'))) in
+  assert_eq
+    "unsigned long x;
+     x = (unsigned long) - 1 / 8;" p
+
+let suite : test = "Test Patch C" >::: [
+    "Test void pointer implicit downcast" >:: test_void_ptr_implicit_downcast;
+    "Test void pointer implicit upcast" >:: test_void_ptr_implicit_upcast;
+    "Test bad pointer cast" >:: test_bad_ptr_cast;
+    "Test bad arg arity" >:: test_bad_arg_arity;
+    "Test bad arg types" >:: test_bad_arg_types;
+    "Test discard" >:: test_discard;
+    "Test bad discard" >:: test_bad_discard;
+    "Test pointer arithmetic" >:: test_ptr_arith;
+    "Test bad pointer arithmetic" >:: test_bad_ptr_arith;
+    "Test bad lvalue post-increment" >:: test_bad_lvalue_posincr;
+    "Test char assign" >:: test_char_assign;
+    "Test char assign ext" >:: test_char_assign_ext;
+    "Test int assign" >:: test_int_assign;
+    "Test char assign signed ext" >:: test_char_assign_signed_ext;
+    "Test char assign unsigned ext" >:: test_char_assign_unsigned_ext;
+    "Test cast precedence" >:: test_cast_precedence;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-higher-vars/test/dune
+++ b/vibes-tools/tools/vibes-higher-vars/test/dune
@@ -1,0 +1,8 @@
+(tests
+ (names test_substituter)
+ (libraries
+   bap_wp
+   vibes-higher-vars
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-higher-vars/test/test_substituter.ml
+++ b/vibes-tools/tools/vibes-higher-vars/test/test_substituter.ml
@@ -1,0 +1,178 @@
+open Core
+open Bap.Std
+open Bap_core_theory
+open Bap_wp
+open OUnit2
+
+module Hvar = Vibes_higher_vars.Higher_var
+module Subst = Vibes_higher_vars.Substituter
+module Errors = Vibes_higher_vars.Errors
+module Naming = Subst.Naming
+
+(* Very lax equality to avoid tid comparison failures *)
+let eq_elt (e1 : Blk.elt) (e2 : Blk.elt) : bool =
+  match e1, e2 with
+  | `Def d1, `Def d2 ->
+    let v1, e1 = Def.lhs d1, Def.rhs d1 in
+    let v2, e2 = Def.lhs d2, Def.rhs d2 in
+    Var.(v1 = v2) && Exp.(e1 = e2)
+  | `Jmp j1, `Jmp j2 ->
+    begin
+      match Jmp.guard j1, Jmp.guard j2 with
+      | None, None -> true
+      | Some g1, Some g2 ->
+        let g1 = KB.Value.get Exp.slot g1 in
+        let g2 = KB.Value.get Exp.slot g2 in
+        Exp.(g1 = g2)
+      | _ -> false
+    end
+  (* We shouldn't hit any of these *)
+  | `Phi _, `Phi _ -> false
+  | _ -> false
+
+let eq_blk_list (b1 : blk term list) (b2 : blk term list) : bool =
+  let f = Fn.compose Seq.to_list Blk.elts in
+  let b1 = List.concat_map b1 ~f in
+  let b2 = List.concat_map b2 ~f in
+  List.equal eq_elt b1 b2
+
+let eq_sub (s1 : sub term) (s2 : sub term) : bool =
+  eq_blk_list
+    (Term.enum blk_t s1 |> Seq.to_list)
+    (Term.enum blk_t s2 |> Seq.to_list)
+
+let to_bir (code : bil) : sub term =
+  Bil_to_bir.bil_to_sub code |> Term.map blk_t ~f:(fun blk ->
+      (* Any jmps that occur after an unconditional jmp should
+         be dropped from the blk. *)
+      let jmps =
+        Term.enum jmp_t blk |> Seq.to_list |>
+        List.fold_until ~init:[] ~finish:List.rev ~f:(fun acc jmp ->
+            let acc = jmp :: acc in
+            if Vibes_bir.Helpers.is_unconditional jmp
+            then Stop (List.rev acc)
+            else Continue acc) in
+      let defs = Seq.to_list @@ Term.enum def_t blk in
+      let tid = Term.tid blk in
+      Blk.create ~tid ~defs ~jmps ())
+
+let do_subst (hvars : Hvar.t list) (code : bil) : sub term =
+  let state = Toplevel.current () in
+  Toplevel.reset ();
+  let result = Toplevel.var "vibes-subst" in
+  let sub = to_bir code in
+  let subst =  Subst.substitute sub ~hvars ~target:X86_target.amd64 in
+  Toplevel.put result subst;
+  let sub = Toplevel.get result in
+  Toplevel.set state;
+  sub
+
+let str_of_sub (sub : sub term) =
+  Term.enum blk_t sub |> Seq.to_list |>
+  List.to_string ~f:Blk.to_string
+
+(* Verify that a higher var stored in a register is handled correctly. *)
+let test_substitute_1 (_ : test_ctxt) : unit =
+  let hvars = Hvar.[{
+      name = "x";
+      value = Registers {
+          at_entry = None;
+          at_exit = Some "RAX";
+          allow_opt = false;
+        };
+    }] in
+  let x = Var.create "x" @@ Imm 64 in
+  let rax = Var.create "RAX" @@ Imm 64 in
+  let rax_reg = Naming.mark_reg_unsafe rax in
+  let num_3 = Word.of_int ~width:64 3 in
+  let code = Bil.[
+      x := int @@ num_3;
+      if_ (var x = int num_3)
+        [jmp (var x)]
+        [];
+    ] in
+  let expected = Bil.[
+      x := int @@ num_3;
+      if_ (var x = int num_3)
+        [jmp (var x)]
+        [];
+      rax_reg := var x;
+    ] |> to_bir in
+  let result = do_subst hvars code in
+  let msg = Format.asprintf
+      "Expected '%s' but got '%s'"
+      (str_of_sub expected) (str_of_sub result) in
+  let comparison = eq_sub result expected in
+  assert_bool msg comparison
+
+(* Verify that a higher var stored on the stack is handled correctly. *)
+let test_substitute_2 (_ : test_ctxt) : unit =
+  let hvars = Hvar.[{
+      name = "x";
+      value = Memory (Frame ("RBP", Word.of_int 0x14 ~width:64));
+    }] in
+  let x = Var.create "x" @@ Imm 64 in
+  let rbp = Var.create "RBP" @@ Imm 64 in
+  let rbp_reg = Naming.mark_reg_unsafe rbp in
+  let mem = Var.create "mem" @@ Mem (`r64, `r8) in
+  let num_3 = Word.of_int ~width:64 3 in
+  let num_14 = Word.of_string "0x14:64" in
+  let code = Bil.[
+      x := int @@ num_3;
+      if_ (var x = int num_3)
+        [jmp (var x)]
+        [];
+    ] in
+  let expected = Bil.[
+      mem :=
+        store
+          ~mem:(var mem)
+          ~addr:(var rbp_reg + int num_14)
+          (int num_3)
+          LittleEndian
+          `r64;
+      if_ (load
+             ~mem:(var mem)
+             ~addr:(var rbp_reg + int num_14)
+             LittleEndian `r64
+           = int num_3)
+        [jmp (load
+                ~mem:(var mem)
+                ~addr:(var rbp_reg + int num_14)
+                LittleEndian `r64)]
+        []
+    ] |> to_bir in
+  let result = do_subst hvars code in
+  let msg = Format.asprintf "Expected '%s' but got '%s'"
+      (str_of_sub expected) (str_of_sub result) in
+  let comparison = eq_sub result expected in
+  assert_bool msg comparison
+
+(* Verify that substitution errors are raised correctly. *)
+let test_substitute_error (_ : test_ctxt) : unit =
+  let hvars = Hvar.[{
+      name = "x";
+      value = Registers {
+          at_entry = Some "FAKE1";
+          at_exit = Some "FAKE2";
+          allow_opt = false;
+        };
+    }] in
+  let x = Var.create "x" (Bil.Imm 64) in
+  let code = Bil.[x := var x] in
+  match do_subst hvars code with
+  | exception (Toplevel.Conflict (Errors.Higher_var_not_substituted _)) -> ()
+  | _ ->  assert_failure "Expected error"
+
+let suite : test = "Test Substituter" >::: [
+    "Test case #1" >:: test_substitute_1;
+    "Test case #2" >:: test_substitute_2;
+    "Test error case" >:: test_substitute_error;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-ir/test/dune
+++ b/vibes-tools/tools/vibes-ir/test/dune
@@ -1,0 +1,7 @@
+(tests
+ (names test_ir)
+ (libraries
+   vibes-ir
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-ir/test/test_ir.ml
+++ b/vibes-tools/tools/vibes-ir/test/test_ir.ml
@@ -1,0 +1,167 @@
+open Core
+open Bap.Std
+open OUnit2
+
+module Ir = Vibes_ir.Types
+
+let in_op (ts : var list) : Ir.Operation.t = {
+  id = Ir.fresh_id ();
+  lhs = List.map ts ~f:(fun t -> Ir.Operand.Var (Ir.Opvar.create t));
+  opcodes = [];
+  optional = false;
+  operands = [];
+}
+
+let out_op (ts : var list) : Ir.Operation.t = {
+  id = Ir.fresh_id ();
+  lhs = [];
+  opcodes = [];
+  optional = false;
+  operands = List.map ts ~f:(fun t -> Ir.Operand.Var (Ir.Opvar.create t));
+}
+
+let simple_op
+    (opcode : Ir.opcode)
+    (arg : var)
+    (args : var list) : Ir.Operation.t = {
+  id = Ir.fresh_id ();
+  lhs = [Var (Ir.Opvar.create arg)];
+  opcodes = [opcode];
+  optional = false;
+  operands = List.map args ~f:(fun t -> Ir.Operand.Var (Ir.Opvar.create t));
+}
+
+let (:=) lhs opcode = fun args -> simple_op opcode lhs args
+
+let op_var_exn : Ir.Operand.t -> Ir.Opvar.t = function
+  | Var v -> v
+  | _ -> failwith "expected opvar"
+
+let (vir1 : Ir.t),
+    (definer_map1 : Ir.Opvar.t Var.Map.t),
+    (user_map1 : Ir.Opvar.t list Var.Map.t),
+    (op_opcodes1 : string list Ir.id_map),
+    (temps1 : var list),
+    (operands1 : int list),
+    (_operations1 : int list),
+    (_oprnd_temps1 : var list) =
+  let t1 = Var.create "_000004ff_t1" (Imm 32) in
+  let t2 = Var.create "_000004ff_t2" (Imm 32) in
+  let t3 = Var.create "_000004ff_t3" (Imm 32) in
+  let mov = "mov" in
+  let temps = [t1; t2; t3] in
+  let op1 = (t2 := mov) [t1] in
+  let op2 = (t3 := mov) [t2] in
+  let ops = [op1; op2] in
+  let blk1 = Ir.Block.{
+      tid = Tid.create ();
+      data = ops;
+      ctrl = [];
+      ins = in_op [t1];
+      outs = out_op [t3];
+      frequency = 1
+    } in
+  let definer_map = Var.Map.of_alist_exn [
+      t1, op_var_exn @@ List.hd_exn blk1.ins.lhs;
+      t2, op_var_exn @@ List.hd_exn op1.lhs;
+      t3, op_var_exn @@ List.hd_exn op2.lhs;
+    ] in
+  let user_map = Var.Map.of_alist_exn [
+      t1, List.map op1.operands ~f:op_var_exn;
+      t2, List.map op2.operands ~f:op_var_exn;
+      t3, List.map blk1.outs.operands ~f:op_var_exn;
+    ] in
+  let op_opcodes = Int.Map.of_alist_exn [
+      op1.id, [mov];
+      op2.id, [mov];
+      blk1.ins.id, [];
+      blk1.outs.id, [];
+    ] in
+  let oprnd_temps = [t1; t1; t2; t2; t3; t3] in
+  let operands =
+    List.concat [
+      blk1.ins.lhs;
+      op1.operands;
+      op1.lhs;
+      op2.operands;
+      op2.lhs;
+      blk1.outs.operands;
+    ] |> List.map ~f:(fun o -> (op_var_exn o).id) in
+  let operations = List.map [blk1.ins; op1; op2; blk1.outs] ~f:(fun o -> o.id) in
+  let vir1 = Ir.{
+      blks = [blk1];
+      congruences = Var.Map.empty;
+    } in
+  vir1, definer_map, user_map, op_opcodes, temps, operands, operations, oprnd_temps
+
+let _equal_gpr_reg r1 r2 = ARM.compare_gpr_reg r1 r2 = 0
+
+let test_definer1 (_ : test_ctxt) : unit =
+  assert_equal
+    ~cmp:(Var.Map.equal Ir.Opvar.equal)
+    definer_map1
+    (Ir.definer_map vir1)
+
+let test_user1 (_ : test_ctxt) : unit  =
+  assert_equal
+    ~cmp:(Var.Map.equal (List.equal Ir.Opvar.equal))
+    user_map1
+    (Ir.users_map vir1)
+
+let test_temps1 (_ : test_ctxt) : unit =
+  assert_equal
+    ~cmp:(Var.Set.equal)
+    (Var.Set.of_list temps1)
+    (Ir.all_temps vir1)
+
+let test_operands1 (_ : test_ctxt) : unit =
+  assert_equal
+    ~cmp:(Int.Set.equal)
+    (Int.Set.of_list operands1)
+    (Ir.all_opvar_ids vir1)
+
+let test_op_opcodes1 (_ : test_ctxt) : unit =
+  assert_equal
+    ~cmp:(Int.Map.equal (List.equal Ir.equal_opcode))
+    op_opcodes1
+    (Ir.operation_to_opcodes vir1)
+
+let dummy_reg_alloc (t : Ir.t) : Ir.t = Ir.map_opvars t ~f:(fun v ->
+    match v.preassign with
+    | Some _ -> v
+    | None ->
+      let var = List.hd_exn v.temps in
+      {v with preassign = Some (Var.create "R0" (Var.typ var))})
+
+let test_dummy_reg_alloc (_ : test_ctxt) : unit =
+  let r0 = Var.create ~is_virtual:false ~fresh:false "R0" (Type.Imm 32) in
+  let ir_alloc = dummy_reg_alloc vir1 in
+  let all_operations =
+    ir_alloc.blks |>
+    List.concat_map ~f:(fun (b : Ir.Block.t) ->
+        b.ins :: b.outs :: b.data @ b.ctrl) in
+  let all_operands = List.concat_map all_operations
+      ~f:(fun (o : Ir.Operation.t) -> o.lhs @ o.operands) in
+  let all_op_vars = List.map all_operands ~f:op_var_exn in
+  let all_regs =
+    List.map all_op_vars ~f:(fun o -> o.preassign) |>
+    List.filter_opt in
+  assert_equal ~cmp:(List.equal Var.equal) [r0; r0; r0; r0; r0; r0]
+    ~printer:(List.to_string ~f:(Fn.compose Sexp.to_string Var.sexp_of_t))
+    all_regs
+
+let suite : test = "Test VIBES IR" >::: [
+    "Test Definer map" >:: test_definer1;
+    "Test User map"  >:: test_user1;
+    "Test All Temps" >:: test_temps1;
+    "Test All Operands" >:: test_operands1;
+    "Test Operation Instructions Map" >:: test_op_opcodes1;
+    "Test Dummy Reg Alloc" >:: test_dummy_reg_alloc;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-linear-ssa/test/dune
+++ b/vibes-tools/tools/vibes-linear-ssa/test/dune
@@ -1,0 +1,7 @@
+(tests
+ (names test_linear_ssa)
+ (libraries
+   vibes-linear-ssa
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-linear-ssa/test/test_linear_ssa.ml
+++ b/vibes-tools/tools/vibes-linear-ssa/test/test_linear_ssa.ml
@@ -1,0 +1,107 @@
+open Core
+open Bap.Std
+open OUnit2
+open Vibes_linear_ssa
+
+let prefix_from (blk : blk term) : string =
+  let tid = Term.tid blk in
+  let tid_str = Tid.to_string tid in
+  String.drop_prefix tid_str 1
+
+let linearize ~(prefix : string) (var : var) : var =
+  let name = Var.name var in
+  let typ = Var.typ var in
+  let new_name = prefix ^ "_" ^ name in
+  let esc = String.substr_replace_all new_name ~pattern:"." ~with_:"_" in
+  Var.create esc typ
+
+let test_orig_name (_ : test_ctxt) : unit =
+  let orig = "_01234567_R0" in
+  let expected = "R0" in
+  let result = Option.value_exn (Utils.orig_name orig) in
+  let err = Format.sprintf "expected '%s' but got '%s'" expected result in
+  let comparison = String.equal result expected in
+  assert_bool err comparison
+
+let test_orig_name_with_ssa (_ : test_ctxt) : unit =
+  let orig = "_01234567_R0_1" in
+  let expected = "R0" in
+  let result = Option.value_exn (Utils.orig_name orig) in 
+  let err = Format.sprintf "expected '%s' but got '%s'" expected result in
+  let comparison = String.equal result expected in
+  assert_bool err comparison
+
+let test_same (_ : test_ctxt) : unit =
+  let a = Var.create "_01234567_R0_1" @@ Imm 32 in
+  let b = Var.create "_76543210_R0" @@ Imm 32 in
+  let result = Utils.same a b in
+  let err =
+    Format.asprintf "Expected '%a' and '%a' to be the 'same'"
+      Var.pp a Var.pp b in
+  assert_bool err result
+
+let test_congruent (_ : test_ctxt) : unit =
+  let a = Var.create "_01234567_R0" (Bil.Imm 32) in
+  let b = Var.create "_76543210_R0" (Bil.Imm 32) in
+  let result = Utils.congruent a b in
+  let err =
+    Format.asprintf "Expected '%a' and '%a' to be 'congruent'"
+      Var.pp a Var.pp b in
+  assert_bool err result
+
+let test_transform (_ : test_ctxt) : unit =
+  let state = Toplevel.current () in
+  Toplevel.reset ();
+  (* Build a dummy subroutine to transform into linear SSA. *)
+  let var_0 = Var.create "R0" (Bil.Imm 32) in
+  let value = Bil.int (Word.of_int 3 ~width:32) in
+  let def_1 = Def.create var_0 value in
+  let def_2 = Def.create var_0 value in
+  let blk_1 = Blk.create () ~defs:[def_1] in
+  let blk_2 = Blk.create () ~defs:[def_2] in
+  let orig_sub = Sub.create () ~name:"foo" ~blks:[blk_1; blk_2] in
+  let sub = Sub.ssa orig_sub in
+  let result = Toplevel.var "linear-ssa" in
+  Toplevel.put result @@ Linearizer.transform sub ~hvars:[];
+  let sub_1 = Toplevel.get result in
+  (* Build the subroutine we expect it to produce. *)
+  let blks = Seq.to_list (Term.enum blk_t sub) in
+  let tids = List.map blks ~f:Term.tid in
+  let prefixes = List.map blks ~f:prefix_from in
+  let var_1 = linearize
+    (Var.with_index var_0 1)
+    ~prefix:(List.nth_exn prefixes 0) in
+  let var_2 = linearize
+    (Var.with_index var_0 2)
+    ~prefix:(List.nth_exn prefixes 1) in
+  let def_1 = Def.create var_1 value ~tid:(Term.tid def_1) in
+  let def_2 = Def.create var_2 value ~tid:(Term.tid def_2) in
+  let blk_1 = Blk.create () ~tid:(List.nth_exn tids 0) ~defs:[def_1] in
+  let blk_2 = Blk.create () ~tid:(List.nth_exn tids 1) ~defs:[def_2] in
+  let expected = [blk_1; blk_2] in
+  let sub_1 =
+    Term.enum blk_t sub_1 |> Seq.to_list |>
+    List.map ~f:Blk.to_string |> String.concat ~sep:"\n" in
+  let sub_2 = List.map expected ~f:Blk.to_string |> String.concat ~sep:"\n" in
+  let err =
+    Format.sprintf
+      "failed to linear SSA sub:\nexpected:\n%sgot:\n%s"
+      sub_2 sub_1 in
+  let comparison = String.equal sub_1 sub_2 in
+  Toplevel.set state;
+  assert_bool err comparison
+
+let suite : test = "Test Linear SSA" >::: [
+    "Test orig_name" >:: test_orig_name;
+    "Test orig_name: with SSA version" >:: test_orig_name_with_ssa;
+    "Test same" >:: test_same;
+    "Test congruent" >:: test_congruent;
+    "Test transform" >:: test_transform;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1

--- a/vibes-tools/tools/vibes-opt/test/dune
+++ b/vibes-tools/tools/vibes-opt/test/dune
@@ -1,6 +1,5 @@
 (tests
  (names test_opt)
- (flags -w -32)
  (libraries
    vibes-opt
    findlib.dynload

--- a/vibes-tools/tools/vibes-opt/test/dune
+++ b/vibes-tools/tools/vibes-opt/test/dune
@@ -1,0 +1,8 @@
+(tests
+ (names test_opt)
+ (flags -w -32)
+ (libraries
+   vibes-opt
+   findlib.dynload
+   threads
+   ounit2))

--- a/vibes-tools/tools/vibes-opt/test/test_opt.ml
+++ b/vibes-tools/tools/vibes-opt/test/test_opt.ml
@@ -46,13 +46,10 @@ let blk_uncond_dir
   Blk.create ~defs:[mov2] ~jmps:[jmp] ()
 
 let apply (blks : blk term list) : blk term list =
-  let state = Toplevel.current () in
-  Toplevel.reset ();
   let result = Toplevel.var "bir-opt" in
   let sub = Sub.create () ~blks in
   Toplevel.put result @@ Vibes_opt.Opt.apply [] sub;
   let sub = Toplevel.get result in
-  Toplevel.set state;
   Seq.to_list @@ Term.enum blk_t sub
 
 let test_redir_1 (_ : test_ctxt) : unit =

--- a/vibes-tools/tools/vibes-opt/test/test_opt.ml
+++ b/vibes-tools/tools/vibes-opt/test/test_opt.ml
@@ -1,0 +1,165 @@
+open Core
+open Bap.Std
+open Bap_core_theory
+open OUnit2
+
+let indirect_tgt : exp = Bil.int @@ Word.of_int ~width:32 42
+let cond : var = Var.create "cond" @@ Imm 32
+let mov1 () : def term = Def.create cond @@ Bil.var cond
+let mov2 () : def term = Def.create cond Bil.(lnot @@ var cond)
+
+let blk_redir () : blk term =
+  let kind = Goto (Indirect indirect_tgt) in
+  let jmp = Jmp.create kind in
+  Blk.create ~jmps:[jmp] ()
+
+let blk_cond_redir (blk_dir : blk term) : blk term =
+  let kind = Goto (Indirect indirect_tgt) in
+  let jmp = Jmp.create ~cond:(Bil.Var cond) kind in
+  let kind2 = Goto (Direct (Term.tid blk_dir)) in
+  let jmp2 = Jmp.create kind2 in
+  Blk.create ~jmps:[jmp; jmp2] ()
+
+let blk_mov_redir (mov1 : def term) : blk term =
+  let kind = Goto (Indirect indirect_tgt) in
+  let jmp = Jmp.create kind in
+  Blk.create ~defs:[mov1] ~jmps:[jmp] ()
+
+let blk_dir
+    ?(blk_fall : blk term option = None)
+    (blk_redir : blk term) : blk term =
+  let kind = Goto (Direct (Term.tid blk_redir)) in
+  let jmp = Jmp.create ~cond:(Bil.Var cond) kind in
+  let jmps = match blk_fall with
+    | None -> [jmp]
+    | Some b ->
+      let kind2 = Goto (Direct (Term.tid b)) in
+      let jmp2 = Jmp.create kind2 in
+      [jmp; jmp2] in
+  Blk.create ~jmps ()
+
+let blk_uncond_dir
+    (mov2 : def term)
+    (blk_mov_redir : blk term) : blk term =
+  let kind = Goto (Direct (Term.tid blk_mov_redir)) in
+  let jmp = Jmp.create ~cond:(Bil.Int Word.b1) kind in
+  Blk.create ~defs:[mov2] ~jmps:[jmp] ()
+
+let apply (blks : blk term list) : blk term list =
+  let state = Toplevel.current () in
+  Toplevel.reset ();
+  let result = Toplevel.var "bir-opt" in
+  let sub = Sub.create () ~blks in
+  Toplevel.put result @@ Vibes_opt.Opt.apply [] sub;
+  let sub = Toplevel.get result in
+  Toplevel.set state;
+  Seq.to_list @@ Term.enum blk_t sub
+
+let test_redir_1 (_ : test_ctxt) : unit =
+  let redir = blk_redir () in
+  let dir = blk_dir redir in
+  let opts = apply [dir; redir] in
+  List.find opts ~f:(fun b ->
+      Tid.equal (Term.tid b) (Term.tid dir)) |>
+  Option.map ~f:(fun b ->
+      Term.enum jmp_t b |> Seq.to_list) |> function
+  | None -> assert_failure "didn't find blk_dir"
+  | Some [] | Some (_ :: _ :: _) -> assert_failure "unexpected block shape"
+  | Some [j] -> Jmp.dst j |> Option.map ~f:Jmp.resolve |> function
+    | None -> assert_failure "didn't find dest"
+    | Some (First _) -> assert_failure "should have optimized"
+    | Some (Second v) ->
+      let tgt = KB.Value.get Exp.slot v in
+      assert_bool "incorrect target" Exp.(tgt = indirect_tgt)    
+
+let test_redir_2 (_ : test_ctxt) : unit =
+  let redir = blk_redir () in
+  let dir = blk_dir redir in
+  let cond_redir = blk_cond_redir dir in
+  let opts = apply [cond_redir; dir; redir] in
+  List.find opts ~f:(fun b ->
+      Tid.equal (Term.tid b) (Term.tid dir)) |>
+  Option.map ~f:(fun b ->
+      Term.enum jmp_t b |> Seq.to_list) |> function
+  | None -> assert_failure "didn't find block"
+  | Some [] | Some (_ :: _ :: _) -> assert_failure "unexpected block shape"
+  | Some [j] -> Jmp.dst j |> Option.map ~f:Jmp.resolve |> function
+    | None -> assert_failure "didn't find dest"
+    | Some (First _) -> assert_failure "should have optimized"
+    | Some (Second v) ->
+      let tgt = KB.Value.get Exp.slot v in
+      assert_bool "incorrect target" Exp.(tgt = indirect_tgt)
+
+let test_redir_3 (_ : test_ctxt) : unit =
+  let mov1 = mov1 () in
+  let mov_redir = blk_mov_redir mov1 in
+  let redir = blk_redir () in
+  let dir = blk_dir redir ~blk_fall:(Some mov_redir) in
+  let opts = apply [dir; mov_redir; redir] in
+  List.find opts ~f:(fun b ->
+      Tid.equal (Term.tid b) (Term.tid dir)) |>
+  Option.map ~f:(fun b ->
+      Term.enum jmp_t b |> Seq.to_list) |> function
+  | None -> assert_failure "didn't find block"
+  | Some [] | Some [_] | Some (_ :: _ :: _ :: _) ->
+    assert_failure "unexpected block shape"
+  | Some [j; _] -> Jmp.dst j |> Option.map ~f:Jmp.resolve |> function
+    | None -> assert_failure "didn't find dest"
+    | Some (First _) -> assert_failure "should have optimized"
+    | Some (Second v) -> 
+      let tgt = KB.Value.get Exp.slot v in
+      assert_bool "incorrect target" Exp.(tgt = indirect_tgt)
+
+let test_merge (_ : test_ctxt) : unit =
+  let mov1 = mov1 () in
+  let mov2 = mov2 () in
+  let mov_redir = blk_mov_redir mov1 in
+  let uncond_dir = blk_uncond_dir mov2 mov_redir in
+  let opts = apply [uncond_dir; mov_redir] in
+  match opts with
+  | [blk] ->
+    let tid = Term.tid blk in
+    let tid_expected = Term.tid uncond_dir in
+    assert_bool
+      (sprintf "expected result to be blk %s, got %s"
+         (Tid.to_string tid)
+         (Tid.to_string tid_expected))
+      Tid.(tid = tid_expected);
+    let defs = Term.enum def_t blk |> Seq.to_list in
+    let expected = [mov2; mov1] in
+    assert_bool
+      (sprintf "Expected defs %s, got %s"
+         (List.to_string ~f:Def.to_string expected)
+         (List.to_string ~f:Def.to_string defs))
+      (List.equal Def.equal defs expected);
+    begin match Term.enum jmp_t blk |> Seq.to_list with
+      | [jmp] -> begin
+          match Jmp.kind jmp with
+          | Goto (Indirect e) ->
+            assert_bool
+              (sprintf "expected result of blk %s to be %s, got %s"
+                 (Tid.to_string tid)
+                 (Exp.to_string indirect_tgt)
+                 (Exp.to_string e))
+              Exp.(e = indirect_tgt)
+          | Goto (Direct _) ->
+            assert_failure "expected indirect jmp, got direct"
+          | _ -> assert_failure "expected goto"
+        end
+      | _ -> assert_failure "expected singleton jmp"
+    end
+  | _ -> assert_failure "expected singleton block as result"
+
+let suite : test = "Test BIR optimizer" >::: [
+    "Test redir 1" >:: test_redir_1;
+    "Test redir 2" >:: test_redir_2;
+    "Test redir 3" >:: test_redir_3;
+    "Test merge" >:: test_merge;
+  ]
+
+let () = match Bap_main.init () with
+  | Ok () -> run_test_tt_main suite
+  | Error e ->
+    Format.eprintf "Failed to initialize BAP: %a"
+      Bap_main.Extension.Error.pp e;
+    exit 1


### PR DESCRIPTION
This is mostly a direct port of the unit tests from `bap-vibes` to the new `vibes-tools` code.