### PR TITLE
More fixes for latest challenge problem

### DIFF
--- a/resources/binja/ogre.py
+++ b/resources/binja/ogre.py
@@ -254,9 +254,15 @@ class OGREEditor(QWidget):
   def _update_functions(self):
     self.available_funcs_widget.clear()
     for s in self.data.get_symbols():
-      if s.auto or s.type != SymbolType.FunctionSymbol:
+      if s.auto:
+        if s.type != SymbolType.ImportedFunctionSymbol:
+          continue
+      elif s.type != SymbolType.FunctionSymbol:
         continue
       f = self.data.get_function_at(s.address)
+      # XXX: how to deal with interworking here?
+      if f.arch != self.data.arch:
+        continue
       self.functions[f.name] = f
       self.available_funcs_widget.addItem(f.name)
     to_remove = []

--- a/resources/binja/ogre.py
+++ b/resources/binja/ogre.py
@@ -267,6 +267,7 @@ class OGREEditor(QWidget):
     self.setLayout(layout)
 
   def _update_functions(self):
+    names = []
     self.available_funcs_widget.clear()
     for s in self.data.get_symbols():
       if s.auto:
@@ -275,11 +276,14 @@ class OGREEditor(QWidget):
       elif s.type != SymbolType.FunctionSymbol:
         continue
       f = self.data.get_function_at(s.address)
-      # XXX: how to deal with interworking here?
-      if f.arch != self.data.arch:
-        continue
-      self.functions[f.name] = f
-      self.available_funcs_widget.addItem(f.name)
+      name = f.name
+      if name in self.functions:
+        name = "%s@%x" % (name, f.start)
+      self.functions[name] = f
+      names.append(name)
+    names.sort()
+    for name in names:
+      self.available_funcs_widget.addItem(name)
     to_remove = []
     for row in range(self.lifted_funcs_widget.count()):
       item = self.lifted_funcs_widget.item(row)

--- a/resources/binja/ogre.py
+++ b/resources/binja/ogre.py
@@ -269,6 +269,7 @@ class OGREEditor(QWidget):
   def _update_functions(self):
     names = []
     self.available_funcs_widget.clear()
+    self.functions.clear()
     for s in self.data.get_symbols():
       if s.auto:
         if s.type != SymbolType.ImportedFunctionSymbol:

--- a/resources/binja/patcheditor.py
+++ b/resources/binja/patcheditor.py
@@ -149,9 +149,7 @@ class PatchEditor(QDialog):
     if not items:
       return
     for item in items:
-      patches = db.get_patches(self.data)
       name = item.text()
-      del patches[name]
       del self.patches[name]
       db.delete_patch(self.data, name)
       row = self.patch_list_widget.row(item)

--- a/resources/binja/patcheditor.py
+++ b/resources/binja/patcheditor.py
@@ -210,8 +210,7 @@ class PatchEditor(QDialog):
 
     # vibes-init doesn't always correctly infer whether the binary is
     # using the Thumb encoding or not.
-    arch = self.data.arch.name
-    if arch == "thumb2" or arch == "thumb2eb":
+    if self.data.arch.name.startswith("thumb2"):
       args.append("--language=bap:llvm-thumb")
 
     ogre = self.ogre.ogre

--- a/resources/binja/utils.py
+++ b/resources/binja/utils.py
@@ -61,7 +61,7 @@ def addr_to_off(bv, addr):
     
 def rodata_of_func(bv, f):
   result = {}
-  for l in f.llil_instructions:
+  for l in f.llil.instructions:
     for r in bv.get_code_refs_from(l.address):
       if bv.get_functions_containing(r):
         continue

--- a/resources/binja/vars.py
+++ b/resources/binja/vars.py
@@ -21,6 +21,14 @@ class HigherVar:
     self.value = value
     self.type = type
 
+  def __eq__(self, h):
+    if isinstance(h, HigherVar):
+      return \
+        self.name == h.name and \
+        self.value == h.value and \
+        self.type == h.type
+    return False
+
   def type_str(self):
     if self.type == HigherVar.REG_VAR:
       return "Register"

--- a/tools/vibes-c-toolkit/lib/core_c.ml
+++ b/tools/vibes-c-toolkit/lib/core_c.ml
@@ -315,7 +315,8 @@ module Make(CT : Theory.Core) = struct
       o !!a !!b
     | VARIABLE (v, _) -> CT.var v
     | CONST_INT (w, _) ->
-      let+ i = CT.int info.word_sort @@ Word.to_bitvec w in
+      let s = T.Bitv.define @@ Word.bitwidth w in
+      let+ i = CT.int s @@ Word.to_bitvec w in
       T.Value.forget i
     | CAST (t, e) ->
       let t' = Patch_c.Exp.typeof info.data e in

--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -209,10 +209,10 @@ module Builtin : S = struct
     end in
     let e = substituter#map_exp exp in
     try Exp.fold_consts e
-    with _ ->
+    with Type_error.T err ->
       let msg = Format.asprintf
           "Vibes_opt.Opt.Builtin.substitute: expression %a is not \
-           well-formed" Exp.pp e in
+           well-formed: %a" Exp.pp e Type_error.pp err in
       raise @@ Ill_typed msg
 
   let equal_kinds j j' = compare_jmp_kind (Jmp.kind j) (Jmp.kind j') = 0

--- a/tools/vibes-patch/lib/utils.mli
+++ b/tools/vibes-patch/lib/utils.mli
@@ -24,6 +24,13 @@ type named_region = {
   name : string;
 }
 
+(** A chunk of code associated with a named symbol. *)
+type symbol_chunk = {
+  addr : int64;
+  size : int64;
+  root : int64;
+}
+
 (** [find_code_region addr spec] looks up the code region in [spec] that
     contains [addr]. *)
 val find_code_region : int64 -> Ogre.doc -> region option
@@ -35,6 +42,10 @@ val find_mapped_region : int64 -> Ogre.doc -> region option
 (** [find_named_region addr spec] looks up the named region in [spec] that
     contains [addr]. *)
 val find_named_region : int64 -> Ogre.doc -> named_region option
+
+(** [find_symbol_chunk addr spec] looks up the symbol chunk in [spec] that
+    contains [addr]. *)
+val find_symbol_chunk : int64 -> Ogre.doc -> symbol_chunk option
 
 (** [find_named_symbol addr spec] looks up the named symbol in [spec] that
     has the address [addr]. *)


### PR DESCRIPTION
1. In `Core_c` we weren't giving the correct sort to constant integers.
2. When we can't find the correct HLIL mapping for the end address of the patch, we can look to see in the rest of the block if such a mapping exists, and if not, traverse the dominator tree for the first match. This also fixes the case where we just cannot find any HLIL mappings.
3. For now, we will avoid providing functions in the higher variables that differ from whatever encoding Binary Ninja told us the binary has (e.g. if the binary is the `thumb2` arch, then don't allow `armv7` functions). Meanwhile, we take advantage of the `symbol-value` attribute in OGRE to mark functions as using either ARM or Thumb encodings.