### PR TITLE
Exclude R13 for PowerPC

### DIFF
--- a/tools/vibes-minizinc/lib/types.ml
+++ b/tools/vibes-minizinc/lib/types.ml
@@ -299,8 +299,9 @@ module Params = struct
           | "R7" when thumb ->
             (* R7 in Thumb mode is usually referring to the frame pointer. *)
             false
-          | "R0" | "R31" when ppc ->
+          | "R0" | "R13" | "R31" when ppc ->
             (* R0 in some special cases refers to the literal value 0.
+               R13 is generally used as the small area data pointer.
                R31 is generally used as the frame pointer. *)
             false
           | _ -> true) in


### PR DESCRIPTION
This register is generally used as the small area data pointer, which is similar to the GP register in MIPS. We should avoid overwriting it in patches.