### PR TITLE
Optimize BIR code when we have short-circuiting conditionals

### DIFF
--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -494,9 +494,10 @@ module Cond : S = struct
     let s1 = G.Node.degree t1 cfg ~dir:`Out in
     let s2 = G.Node.degree t1 cfg ~dir:`Out in
     guard ((s1 <> 2 && s2 <> 2) || (s1 = 2 && s2 = 2)) @@ fun () ->
-    let b1, b2, _t1, t2 =
-      if Tree.is_descendant_of doms ~parent:t1 t2
-      then b1, b2, t1, t2 else b2, b1, t2, t1 in
+    let dom12 = Tree.is_descendant_of doms ~parent:t1 t2 in
+    let dom21 = Tree.is_descendant_of doms ~parent:t2 t1 in
+    guard (dom12 || dom21) @@ fun () ->
+    let b1, b2, _t1, t2 = if dom12 then b1, b2, t1, t2 else b2, b1, t2, t1 in
     let d1 = Option.value_exn (last_def_of b1 v) in
     let d2 = Option.value_exn (last_def_of b2 v) in
     let j11 = Seq.hd_exn @@ Term.enum jmp_t b1 in

--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -598,10 +598,10 @@ module Short_circ_cond : S = struct
     | Some (v, tid, k1, k2) ->
       match Seq.to_list @@ G.Node.preds tid cfg with
       | [t1; t2] ->
-        begin transform cfg doms v t1 t2 k1 k2 tid sub >>= function
-          | None -> loop sub ~excluded:(Set.add excluded tid)
-          | Some sub -> loop sub ~excluded
-        end
+        let* sub =
+          transform cfg doms v t1 t2 k1 k2 tid sub >>|
+          Option.value ~default:sub in
+        loop sub ~excluded:(Set.add excluded tid)
       | _ ->
         failwithf "Expected two predecessors for block %s"
           (Tid.to_string tid) ()

--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -577,7 +577,6 @@ module Short_circ_cond : S = struct
             | BinOp (NEQ, Var v, Int w)
               when Var.is_virtual v
                 && Word.is_zero w
-                && not (Blk.defines_var blk v)
                 && not (used_after sub v tid doms) ->
               !!(Some (v, tid, t1, t2))
             | _ -> !!None

--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -527,10 +527,10 @@ module Short_circ_cond : S = struct
           | Goto (Direct t), Goto (Direct f) ->
             let j21 = Seq.hd_exn @@ Term.enum jmp_t b2 in
             begin match Jmp.kind j21 with
-              | Goto (Direct c) ->
+              | Goto (Direct c) when Tid.equal c tid ->
                 let and_ = Tid.equal t t2 && Tid.equal f tid in
                 let or_ = Tid.equal t tid && Tid.equal f t2 in
-                guard (Tid.equal c tid && (or_ || and_)) @@ fun () ->
+                guard (or_ || and_) @@ fun () ->
                 let j11, j12 =
                   if and_ then transform_and j11 j12 d1 k2
                   else transform_or j11 j12 d1 k1 in
@@ -602,7 +602,9 @@ module Short_circ_cond : S = struct
           | None -> loop sub ~excluded:(Set.add excluded tid)
           | Some sub -> loop sub ~excluded
         end
-      | _ -> failwith "Expected two predecessors"
+      | _ ->
+        failwithf "Expected two predecessors for block %s"
+          (Tid.to_string tid) ()
 
   let go : t = fun _ sub -> loop sub
 

--- a/tools/vibes-opt/lib/opt.ml
+++ b/tools/vibes-opt/lib/opt.ml
@@ -360,9 +360,8 @@ module Contract : S = struct
            contraction. *)
         if Tid.(tid <> entry_tid)
         && not (Term.has_attr blk Tags.split)
-        && Seq.is_empty @@ Term.enum def_t blk then
-          let jmps = Term.enum jmp_t blk |> Seq.to_list in
-          match jmps with
+        && Term.length def_t blk = 0 then
+          match Term.enum jmp_t blk |> Seq.to_list with
           | [jmp] when Helper.is_unconditional jmp -> begin
               match Jmp.kind jmp with
               | Goto lbl -> Some (tid, lbl)

--- a/tools/vibes-opt/lib/opt.mli
+++ b/tools/vibes-opt/lib/opt.mli
@@ -42,6 +42,9 @@ module Merge : S
 (** Edge contraction. *)
 module Contract : S
 
+(** Short-circuiting conditional simplification. *)
+module Short_circ_cond : S
+
 (** Registers an optimization pass. By default the above passes
     are included. *)
 val register : (module S) -> unit


### PR DESCRIPTION
The handling of short-circuiting boolean `&&` and `||` in our C front-end generates correct but naive code. Take for example the following program from our testsuite:

```
{
  int *a, i, retval;
  if (i < 3 && i >= 0) {
    retval = a[i];
  } else {
    retval = -1;
  }
}
```

This gets compiled to the following BIL code:

```
{
  #0 := i <$ 3
  if (#0 <> 0) {
    #0 := 0 <=$ i
  }
  if (#0 <> 0) {
    retval := mem[a + 4 * i, el]:u32
  }
  else {
    retval := 0xFFFFFFFF
  }
}
```

We're carrying the result of each condition of the `&&` in the virtual variable `#0`, which is never used anywhere except in the final `if` statement. Unsurprisingly, the generated assembly for this is highly unoptimal (especially in terms of size). The corresponding BIR code:

```
0000001e: sub bounds-check.bir()
          
          
0000001b:
00000021: i := reg:R1
00000022: a := reg:R0
0000001c: #0 := i <$ 3
0000001a: when #0 <> 0 goto %0000000a
00000019: goto %0000000d

0000000a:
0000000b: #0 := 0 <=$ i
0000000c: goto %0000000d

0000000d:
00000016: when #0 <> 0 goto %0000000e
00000015: goto %00000011

00000011:
00000012: retval := 0xFFFFFFFF
00000013: goto %00000020

0000000e:
0000000f: retval := mem[a + 4 * i, el]:u32
00000010: goto %00000020

00000020:
00000023: reg:R3 := retval
```

With this new optimization pass applied, we get the following BIR code:

```
0000001e: sub bounds-check.bir()
          
          
0000001b:
00000021: i := reg:R1
00000022: a := reg:R0
0000001a: when i <$ 3 goto %0000000a
00000019: goto %00000011

0000000a:
0000000c: when 0 <=$ i goto %0000000e
00000026: goto %00000011

00000011:
00000012: retval := 0xFFFFFFFF
00000013: goto %00000020

0000000e:
0000000f: retval := mem[a + 4 * i, el]:u32
00000010: goto %00000020

00000020:
00000023: reg:R3 := retval
```

As we can see, it is far more canonical with what a "good" compiler would generate.